### PR TITLE
Use latest runners for tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-2019, macos-11]
+        os: [ ubuntu-latest, windows-latest, macos-latest, macos-14]
         rust: [ stable ]
 
     needs: [linters]


### PR DESCRIPTION
- Updated macOS, Ubuntu, and Windows runners to latest
- Added `macos-14` to test on apple silicon (arm64) platforms

/cc @mdsteele