### PR TITLE
Add foreign function interface (ffi) support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for Cargo
+  - package-ecosystem: cargo # See documentation for possible values
+    directory: / # Location of package manifests
+    allow:
+      - dependency-type: all
+    schedule:
+      interval: daily
+    reviewers: [mdsteele]
+
+  # Maintain dependencies for Cargo
+  - package-ecosystem: cargo # See documentation for possible values
+    directory: /ffi # Location of package manifests
+    allow:
+      - dependency-type: all
+    schedule:
+      interval: daily
+    reviewers: [mdsteele]
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: /
+    schedule:
+      interval: daily
+    reviewers: [mdsteele]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,26 @@
-[package]
-name = "msi"
+[workspace]
+members = [".", "ffi"]
+default-members = [".", "ffi"]
+
+[workspace.package]
 version = "0.7.0"
 authors = ["Matthew D. Steele <mdsteele@alum.mit.edu>"]
-description = "Read/write Windows Installer (MSI) files"
 repository = "https://github.com/mdsteele/rust-msi"
 keywords = ["msi", "windows", "installer", "package"]
 license = "MIT"
 readme = "README.md"
 edition = "2021"
+
+[package]
+name = "msi"
+version.workspace = true
+authors.workspace = true
+description = "Read/write Windows Installer (MSI) files"
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+edition.workspace = true
 
 [dependencies]
 byteorder = "1"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 chrono = "0.4.37"
-msi = { path = "../" }
-safer-ffi = { version = "0.1.5", features = ["headers"] }
+msi = { version = "0.7.0", path = "../" }
+safer-ffi = { version = "0.1.6", features = ["headers", "python-headers"] }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "msi_ffi"
+version.workspace = true
+authors.workspace = true
+description = "Basic FFI interface for reading Windows Installer (MSI) files, using the `msi` crate."
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
+readme.workspace = true
+edition.workspace = true
+
+[lib]
+name = "msi_ffi"
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+chrono = "0.4.37"
+msi = { path = "../" }
+safer-ffi = { version = "0.1.5", features = ["headers"] }

--- a/ffi/src/bin/generate-headers.rs
+++ b/ffi/src/bin/generate-headers.rs
@@ -1,0 +1,3 @@
+fn main() -> ::std::io::Result<()> {
+    ::msi_ffi::generate_headers()
+}

--- a/ffi/src/bin/generate-headers.rs
+++ b/ffi/src/bin/generate-headers.rs
@@ -4,7 +4,12 @@ fn main() -> ::std::io::Result<()> {
     if let Some(lang) = ::std::env::args_os().nth(1) {
         msi_ffi::generate_headers(
             lang.to_str().unwrap(),
-            ::std::env::args_os().nth(2).unwrap_or_default().to_str().unwrap().to_string(),
+            ::std::env::args_os()
+                .nth(2)
+                .unwrap_or_default()
+                .to_str()
+                .unwrap()
+                .to_string(),
         )
     } else {
         println!("No language specified.");

--- a/ffi/src/bin/generate-headers.rs
+++ b/ffi/src/bin/generate-headers.rs
@@ -1,8 +1,8 @@
 fn main() -> ::std::io::Result<()> {
     println!("Syntax: generate-headers <language> <filename>");
     println!("Supported languages: c, csharp (cs) (c#), python (py)");
-    if let Some(lang) = ::std::env::args_os().nth(1) {
-        msi_ffi::generate_headers(
+    match ::std::env::args_os().nth(1) {
+        Some(lang) => msi_ffi::generate_headers(
             lang.to_str().unwrap(),
             ::std::env::args_os()
                 .nth(2)
@@ -10,9 +10,10 @@ fn main() -> ::std::io::Result<()> {
                 .to_str()
                 .unwrap()
                 .to_string(),
-        )
-    } else {
-        println!("No language specified.");
-        Ok(())
+        ),
+        None => {
+            println!("No language specified.");
+            Ok(())
+        }
     }
 }

--- a/ffi/src/bin/generate-headers.rs
+++ b/ffi/src/bin/generate-headers.rs
@@ -1,3 +1,13 @@
 fn main() -> ::std::io::Result<()> {
-    ::msi_ffi::generate_headers()
+    println!("Syntax: generate-headers <language> <filename>");
+    println!("Supported languages: c, csharp (cs) (c#), python (py)");
+    if let Some(lang) = ::std::env::args_os().nth(1) {
+        msi_ffi::generate_headers(
+            lang.to_str().unwrap(),
+            ::std::env::args_os().nth(2).unwrap_or_default().to_str().unwrap().to_string(),
+        )
+    } else {
+        println!("No language specified.");
+        Ok(())
+    }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,0 +1,187 @@
+//! A basic foreign function interface (FFI) for "only" reading information
+//! of [Windows Installer](https://en.wikipedia.org/wiki/Windows_Installer)
+//! (MSI) files, built on top of the [msi](https://crates.io/crates/msi) crate.
+
+#![warn(missing_docs)]
+
+use chrono::prelude::{DateTime, Utc};
+use msi::{Package, Select};
+use safer_ffi::prelude::*;
+use std::io;
+use std::path::Path;
+
+// ========================================================================= //
+
+/// Information about an MSI file.
+#[derive_ReprC]
+#[repr(C)]
+pub struct MsiInformation {
+    /// Architecture of the MSI installer.
+    arch: repr_c::String,
+    /// Author of the MSI file.
+    author: repr_c::String,
+    /// Comments about the MSI file.
+    comments: repr_c::String,
+    /// The application that created the MSI file.
+    creating_application: repr_c::String,
+    /// The creation time in RFC2822 format.
+    creation_time: repr_c::String,
+    /// The BCP-47 codes of the languages in the MSI file.
+    languages: repr_c::Vec<repr_c::String>,
+    /// The subject of the MSI file.
+    subject: repr_c::String,
+    /// The title of the MSI file.
+    title: repr_c::String,
+    /// The UUID of the MSI file.
+    uuid: repr_c::String,
+    /// Word count
+    word_count: i32,
+
+    /// Indicates whether the MSI file has a digital signature.
+    has_digital_signature: bool,
+
+    /// The names of the tables in the MSI database.
+    table_names: repr_c::Vec<repr_c::String>,
+}
+
+// ========================================================================= //
+
+/// Gets the information of an MSI file at the given path.
+#[ffi_export]
+fn get_information(path: char_p::Ref<'_>) -> MsiInformation {
+    let file_handle = std::fs::File::open(Path::new(path.to_str())).unwrap();
+    let package = Package::open(file_handle).unwrap();
+
+    MsiInformation {
+        arch: package
+            .summary_info()
+            .arch()
+            .unwrap_or_default()
+            .to_string()
+            .into(),
+        author: package
+            .summary_info()
+            .author()
+            .unwrap_or_default()
+            .to_string()
+            .into(),
+        comments: package
+            .summary_info()
+            .comments()
+            .unwrap_or_default()
+            .to_string()
+            .into(),
+        creating_application: package
+            .summary_info()
+            .creating_application()
+            .unwrap_or_default()
+            .to_string()
+            .into(),
+        creation_time: {
+            if let Some(time) = package.summary_info().creation_time() {
+                let datetime: DateTime<Utc> = time.into();
+                datetime.to_rfc2822().into()
+            } else {
+                "".into()
+            }
+        },
+        languages: {
+            let mut langs: Vec<repr_c::String> = Vec::new();
+            for language in package.summary_info().languages() {
+                langs.push(language.code().to_string().into());
+            }
+            langs.into()
+        },
+        subject: package
+            .summary_info()
+            .subject()
+            .unwrap_or_default()
+            .to_string()
+            .into(),
+        title: package
+            .summary_info()
+            .title()
+            .unwrap_or_default()
+            .to_string()
+            .into(),
+        uuid: package
+            .summary_info()
+            .uuid()
+            .unwrap_or_default()
+            .to_string()
+            .into(),
+        word_count: package.summary_info().word_count().unwrap_or_default(),
+
+        has_digital_signature: package.has_digital_signature(),
+
+        table_names: {
+            let mut names: Vec<repr_c::String> = Vec::new();
+            for table in package.tables() {
+                names.push(table.name().to_string().into());
+            }
+            names.into()
+        },
+    }
+}
+
+/// Frees the memory of the given MsiInformation.
+#[ffi_export]
+fn free_information(info: MsiInformation) {
+    drop(info);
+}
+
+/// Get the specified table from the MSI file.
+#[ffi_export]
+fn get_table(
+    path: char_p::Ref<'_>,
+    table_name: char_p::Ref<'_>,
+) -> repr_c::Vec<repr_c::Vec<repr_c::String>> {
+    let file_handle = std::fs::File::open(Path::new(path.to_str())).unwrap();
+    let mut package = Package::open(file_handle).unwrap();
+
+    let mut result: Vec<repr_c::Vec<repr_c::String>> = Vec::new();
+
+    if !package.has_table(table_name.to_str()) {
+        return Vec::new().into();
+    }
+
+    let table = package.get_table(table_name.to_str()).unwrap();
+
+    // first, we add column names
+    let mut columns: Vec<repr_c::String> = Vec::new();
+    for column in table.columns() {
+        columns.push(column.name().to_string().into());
+    }
+    result.push(columns.into());
+
+    // then, we add the rows
+    package
+        .select_rows(Select::table(table_name.to_str()))
+        .expect("select")
+        .for_each(|row| {
+            let mut row_data: Vec<repr_c::String> =
+                Vec::with_capacity(row.len());
+            for index in 0..row.len() {
+                row_data.push(row[index].to_string().into());
+            }
+            result.push(row_data.into());
+        });
+
+    result.into()
+}
+
+/// Frees the memory of the get_table result.
+#[ffi_export]
+fn free_table(table: repr_c::Vec<repr_c::Vec<repr_c::String>>) {
+    drop(table);
+}
+
+/// Generate headers/bindings for get_information() function.
+pub fn generate_headers() -> io::Result<()> {
+    ::safer_ffi::headers::builder()
+        .with_language(::safer_ffi::headers::Language::CSharp)
+        .to_file("generated.cs")?
+        .generate()
+}
+
+// ========================================================================= //

--- a/src/internal/stringpool.rs
+++ b/src/internal/stringpool.rs
@@ -102,9 +102,9 @@ impl StringPoolBuilder {
             let mut length = length as u32;
             let mut refcount = reader.read_u16::<LittleEndian>()?;
             if length == 0 && refcount > 0 {
-                length = ((refcount as u32) << 16)
-                    | (reader.read_u16::<LittleEndian>()? as u32);
+                let lsb = reader.read_u16::<LittleEndian>()? as u32;
                 refcount = reader.read_u16::<LittleEndian>()?;
+                length = (((refcount) as u32) << 16) | lsb;
             }
             lengths_and_refcounts.push((length, refcount));
         }

--- a/src/internal/stringpool.rs
+++ b/src/internal/stringpool.rs
@@ -102,9 +102,9 @@ impl StringPoolBuilder {
             let mut length = length as u32;
             let mut refcount = reader.read_u16::<LittleEndian>()?;
             if length == 0 && refcount > 0 {
-                let lsb = reader.read_u16::<LittleEndian>()? as u32;
+                length = ((refcount as u32) << 16)
+                    | (reader.read_u16::<LittleEndian>()? as u32);
                 refcount = reader.read_u16::<LittleEndian>()?;
-                length = (((refcount) as u32) << 16) | lsb;
             }
             lengths_and_refcounts.push((length, refcount));
         }


### PR DESCRIPTION
Hello @mdsteele,

I wanted to add support for reading MSI files on all platforms (Windows, Linux, and macOS) to a project written in C#.  While researching, I found no C# libraries that were platform-independent and could work with MSI files on all OSes but found this Rust library instead. Looking into calling Rust functions from C#, I found several guides on the internet that suggested making some changes to the Rust code (and this PR does those changes).

However, there are some "warnings" emitted by the compiler after adding `#[no_mangle]` trait. I am not familiar with Rust, and hence, don't know if it's safe to ignore those warnings or whether we need to make some changes in the internal code of the library. Therefore, I kindly request you to look into making the needed changes (if required) and add support for this library to be able to call from .NET C#.

Thanks.

References:
- https://arschles.com/blog/csharp-rust
- https://copyprogramming.com/howto/calling-rust-from-c#
- https://codingupastorm.dev/2020/05/04/executing-rust-from-csharp