### PR TITLE
Skip `DocumentSummaryInformation` stream when parsing

### DIFF
--- a/src/internal/stream.rs
+++ b/src/internal/stream.rs
@@ -1,6 +1,6 @@
 use crate::internal::streamname::{
-    self, DIGITAL_SIGNATURE_STREAM_NAME, MSI_DIGITAL_SIGNATURE_EX_STREAM_NAME,
-    SUMMARY_INFO_STREAM_NAME,
+    self, DIGITAL_SIGNATURE_STREAM_NAME, DOCUMENT_SUMMARY_INFO_STREAM_NAME,
+    MSI_DIGITAL_SIGNATURE_EX_STREAM_NAME, SUMMARY_INFO_STREAM_NAME,
 };
 use cfb;
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -87,6 +87,7 @@ impl<'a, F: 'a> Iterator for Streams<'a, F> {
                 || entry.name() == DIGITAL_SIGNATURE_STREAM_NAME
                 || entry.name() == MSI_DIGITAL_SIGNATURE_EX_STREAM_NAME
                 || entry.name() == SUMMARY_INFO_STREAM_NAME
+                || entry.name() == DOCUMENT_SUMMARY_INFO_STREAM_NAME
             {
                 continue;
             }

--- a/src/internal/streamname.rs
+++ b/src/internal/streamname.rs
@@ -6,6 +6,8 @@ pub const DIGITAL_SIGNATURE_STREAM_NAME: &str = "\u{5}DigitalSignature";
 pub const MSI_DIGITAL_SIGNATURE_EX_STREAM_NAME: &str =
     "\u{5}MsiDigitalSignatureEx";
 pub const SUMMARY_INFO_STREAM_NAME: &str = "\u{5}SummaryInformation";
+pub const DOCUMENT_SUMMARY_INFO_STREAM_NAME: &str =
+    "\u{5}DocumentSummaryInformation";
 
 const TABLE_PREFIX: char = '\u{4840}';
 


### PR DESCRIPTION
Resolves #28.

We skip some streams with special names. In this PR I've added a stream with the name `\u{5}DocumentSummaryInformation`.