### PR TITLE
Limit the number of rows in the table to 65536

### DIFF
--- a/src/internal/table.rs
+++ b/src/internal/table.rs
@@ -109,6 +109,8 @@ impl Table {
         let num_columns = self.columns.len();
         let num_rows =
             if row_size > 0 { (data_length / row_size) as usize } else { 0 };
+        // The number of rows cannot exceed 65536, according to this FAQ:
+        // http://www.installsite.org/pages/en/msifaq/a/1043.htm
         if num_rows > 65536 {
             invalid_data!(
                 "Number of rows is too large ({} > 65536)",

--- a/src/internal/table.rs
+++ b/src/internal/table.rs
@@ -109,6 +109,12 @@ impl Table {
         let num_columns = self.columns.len();
         let num_rows =
             if row_size > 0 { (data_length / row_size) as usize } else { 0 };
+        if num_rows > 65536 {
+            invalid_data!(
+                "Number of rows is too large ({} > 65536)",
+                num_rows
+            );
+        }
         let mut rows =
             vec![Vec::<ValueRef>::with_capacity(num_columns); num_rows];
         for column in self.columns.iter() {


### PR DESCRIPTION
In some cases the stream length may be corrupted. This leads to a very large number of rows, which causes the library to hang when opening a file.

The maximum number of rows is 65536, according to this FAQ: http://www.installsite.org/pages/en/msifaq/a/1043.htm.

This PR limits the number of rows in the table to 65536.