### PR TITLE
Use implicit `iter` and `into_iter` loops

### DIFF
--- a/examples/msiinfo.rs
+++ b/examples/msiinfo.rs
@@ -103,14 +103,14 @@ fn print_table_contents<F: Read + Seek>(
     }
     {
         let mut line = String::new();
-        for &width in col_widths.iter() {
+        for &width in &col_widths {
             let string = pad(String::new(), '-', width);
             line.push_str(&string);
             line.push_str("  ");
         }
         println!("{line}");
     }
-    for row in rows.into_iter() {
+    for row in rows {
         let mut line = String::new();
         for (index, value) in row.into_iter().enumerate() {
             let string = pad(value, ' ', col_widths[index]);

--- a/examples/msiquery.rs
+++ b/examples/msiquery.rs
@@ -83,14 +83,14 @@ fn process_select_query(pair: Pair, package: &mut Package) {
     }
     {
         let mut line = String::new();
-        for &width in col_widths.iter() {
+        for &width in &col_widths {
             let string = pad(String::new(), '-', width);
             line.push_str(&string);
             line.push_str("  ");
         }
         println!("{line}");
     }
-    for row in row_strings.into_iter() {
+    for row in row_strings {
         let mut line = String::new();
         for (index, value) in row.into_iter().enumerate() {
             let string = pad(value, ' ', col_widths[index]);

--- a/src/internal/codepage.rs
+++ b/src/internal/codepage.rs
@@ -305,7 +305,7 @@ mod tests {
             CodePage::Iso88598,
             CodePage::Utf8,
         ];
-        for &codepage in codepages.iter() {
+        for &codepage in codepages {
             assert_eq!(CodePage::from_id(codepage.id()), Some(codepage));
         }
     }

--- a/src/internal/language.rs
+++ b/src/internal/language.rs
@@ -49,10 +49,10 @@ impl Language {
     /// ```
     pub fn from_tag(tag: &str) -> Language {
         let parts: Vec<&str> = tag.splitn(2, '-').collect();
-        for &(lang_code, lang_tag, sublangs) in LANGUAGES.iter() {
+        for &(lang_code, lang_tag, sublangs) in LANGUAGES {
             if lang_tag == parts[0] {
                 if parts.len() > 1 {
-                    for &(sublang_code, sublang_tag) in sublangs.iter() {
+                    for &(sublang_code, sublang_tag) in sublangs {
                         if sublang_tag == tag {
                             return Language::new(lang_code, sublang_code);
                         }
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn lang_codes_are_unique() {
         let mut codes = HashSet::<u16>::new();
-        for &(lang_code, _, _) in LANGUAGES.iter() {
+        for &(lang_code, _, _) in LANGUAGES {
             assert!(
                 !codes.contains(&lang_code),
                 "Language table repeats lang code 0x{lang_code:02x}"
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     fn lang_tags_are_unique() {
         let mut tags = HashSet::<&str>::new();
-        for &(_, lang_tag, _) in LANGUAGES.iter() {
+        for &(_, lang_tag, _) in LANGUAGES {
             assert!(
                 !tags.contains(&lang_tag),
                 "Language table repeats lang tag {lang_tag:?}"
@@ -356,7 +356,7 @@ mod tests {
     #[test]
     fn lang_codes_are_sorted() {
         let mut prev_code: u16 = 0;
-        for &(lang_code, _, _) in LANGUAGES.iter() {
+        for &(lang_code, _, _) in LANGUAGES {
             assert!(
                 lang_code >= prev_code,
                 "LANGUAGES table is not sorted, 0x{lang_code:02x} is out of \
@@ -368,9 +368,9 @@ mod tests {
 
     #[test]
     fn sublang_codes_are_unique() {
-        for &(lang_code, lang_tag, sublangs) in LANGUAGES.iter() {
+        for &(lang_code, lang_tag, sublangs) in LANGUAGES {
             let mut codes = HashSet::<u16>::new();
-            for &(sublang_code, _) in sublangs.iter() {
+            for &(sublang_code, _) in sublangs {
                 assert!(
                     !codes.contains(&sublang_code),
                     "Sublanguage table for 0x{lang_code:02x} ({lang_tag}) \
@@ -383,9 +383,9 @@ mod tests {
 
     #[test]
     fn sublang_tags_are_unique() {
-        for &(lang_code, lang_tag, sublangs) in LANGUAGES.iter() {
+        for &(lang_code, lang_tag, sublangs) in LANGUAGES {
             let mut tags = HashSet::<&str>::new();
-            for &(_, sublang_tag) in sublangs.iter() {
+            for &(_, sublang_tag) in sublangs {
                 assert!(
                     !tags.contains(&sublang_tag),
                     "Sublanguage table for 0x{lang_code:02x} ({lang_tag}) \
@@ -398,9 +398,9 @@ mod tests {
 
     #[test]
     fn sublang_codes_are_sorted() {
-        for &(lang_code, lang_tag, sublangs) in LANGUAGES.iter() {
+        for &(lang_code, lang_tag, sublangs) in LANGUAGES {
             let mut prev_code: u16 = 0;
-            for &(sublang_code, sublang_tag) in sublangs.iter() {
+            for &(sublang_code, sublang_tag) in sublangs {
                 assert!(
                     sublang_code >= prev_code,
                     "Sublanguage table for 0x{lang_code:02x} ({lang_tag}) \
@@ -414,8 +414,8 @@ mod tests {
 
     #[test]
     fn sublang_tags_start_with_lang_tag() {
-        for &(_, lang_tag, sublangs) in LANGUAGES.iter() {
-            for &(_, sublang_tag) in sublangs.iter() {
+        for &(_, lang_tag, sublangs) in LANGUAGES {
+            for &(_, sublang_tag) in sublangs {
                 assert!(
                     sublang_tag.starts_with(&format!("{lang_tag}-")),
                     "{sublang_tag:?} is not a sublanguage of {lang_tag:?}"

--- a/src/internal/package.rs
+++ b/src/internal/package.rs
@@ -373,7 +373,7 @@ impl<F: Read + Seek> Package<F> {
             let stream_name = table.stream_name();
             if comp.exists(&stream_name) {
                 let stream = comp.open_stream(&stream_name)?;
-                for value_refs in table.read_rows(stream)?.into_iter() {
+                for value_refs in table.read_rows(stream)? {
                     let table_name = value_refs[0]
                         .to_value(&string_pool)
                         .as_str()
@@ -397,7 +397,7 @@ impl<F: Read + Seek> Package<F> {
             }
         }
         // Construct Table objects from column/validation data:
-        for (table_name, column_specs) in columns_map.into_iter() {
+        for (table_name, column_specs) in columns_map {
             if column_specs.is_empty() {
                 invalid_data!("No columns found for table {:?}", table_name);
             }
@@ -411,7 +411,7 @@ impl<F: Read + Seek> Package<F> {
                 );
             }
             let mut columns = Vec::<Column>::with_capacity(column_specs.len());
-            for (_, (column_name, bitfield)) in column_specs.into_iter() {
+            for (_, (column_name, bitfield)) in column_specs {
                 let mut builder = Column::build(column_name.as_str());
                 let key = (table_name.clone(), column_name);
                 if let Some(value_refs) = validation_map.get(&key) {
@@ -588,7 +588,7 @@ impl<F: Read + Write + Seek> Package<F> {
         }
         {
             let mut column_names = HashSet::<&str>::new();
-            for column in columns.iter() {
+            for column in &columns {
                 let name = column.name();
                 if !Column::is_valid_name(name) {
                     invalid_input!("{:?} is not a valid column name", name);

--- a/src/internal/propset.rs
+++ b/src/internal/propset.rs
@@ -286,7 +286,7 @@ impl PropertySet {
             CodePage::default()
         };
         let mut property_values = BTreeMap::<u32, PropertyValue>::new();
-        for (name, offset) in property_offsets.into_iter() {
+        for (name, offset) in property_offsets {
             reader.seek(SeekFrom::Start(
                 section_offset as u64 + offset as u64,
             ))?;
@@ -316,7 +316,7 @@ impl PropertySet {
         // Property set header:
         writer.write_u16::<LittleEndian>(BYTE_ORDER_MARK)?;
         let mut format_version = PropertyFormatVersion::V0;
-        for (_, value) in self.properties.iter() {
+        for (_, value) in &self.properties {
             format_version = cmp::max(format_version, value.minimum_version());
         }
         writer.write_u16::<LittleEndian>(format_version.version_number())?;
@@ -337,7 +337,7 @@ impl PropertySet {
         let num_properties = self.properties.len() as u32;
         let mut section_size: u32 = 8 + 8 * num_properties;
         let mut property_offsets: Vec<u32> = Vec::new();
-        for (_, value) in self.properties.iter() {
+        for (_, value) in &self.properties {
             property_offsets.push(section_size);
             section_size += value.size_including_padding();
         }
@@ -347,7 +347,7 @@ impl PropertySet {
             writer.write_u32::<LittleEndian>(name)?;
             writer.write_u32::<LittleEndian>(property_offsets[index])?;
         }
-        for (_, value) in self.properties.iter() {
+        for (_, value) in &self.properties {
             value.write(writer.by_ref(), self.codepage)?;
         }
         Ok(())
@@ -502,7 +502,7 @@ mod tests {
             PropertyValue::FileTime(sat_2017_mar_18_at_18_46_36_gmt),
         ];
         let codepage = CodePage::Utf8;
-        for value in values.iter() {
+        for value in values {
             let mut output = Vec::<u8>::new();
             value.write(&mut output, codepage).unwrap();
             let parsed =

--- a/src/internal/stringpool.rs
+++ b/src/internal/stringpool.rs
@@ -117,7 +117,7 @@ impl StringPoolBuilder {
         mut reader: R,
     ) -> io::Result<StringPool> {
         let mut strings = Vec::<(String, u16)>::new();
-        for (length, refcount) in self.lengths_and_refcounts.into_iter() {
+        for (length, refcount) in self.lengths_and_refcounts {
             let mut buffer = vec![0u8; length as usize];
             reader.read_exact(&mut buffer)?;
             strings.push((self.codepage.decode(&buffer), refcount));
@@ -282,7 +282,7 @@ impl StringPool {
 
     /// Writes to the `_StringData` table.
     pub fn write_data<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        for (string, _) in self.strings.iter() {
+        for (string, _) in &self.strings {
             writer.write_all(&self.codepage.encode(string.as_str()))?;
         }
         Ok(())

--- a/src/internal/summary.rs
+++ b/src/internal/summary.rs
@@ -229,7 +229,7 @@ impl SummaryInfo {
         };
         template.push(';');
         let mut first = true;
-        for language in languages.iter() {
+        for language in languages {
             if first {
                 first = false;
             } else {

--- a/src/internal/table.rs
+++ b/src/internal/table.rs
@@ -119,9 +119,9 @@ impl Table {
         }
         let mut rows =
             vec![Vec::<ValueRef>::with_capacity(num_columns); num_rows];
-        for column in self.columns.iter() {
+        for column in &self.columns {
             let coltype = column.coltype();
-            for row in rows.iter_mut() {
+            for row in &mut rows {
                 row.push(
                     coltype.read_value(&mut reader, self.long_string_refs)?,
                 );
@@ -137,7 +137,7 @@ impl Table {
     ) -> io::Result<()> {
         for (index, column) in self.columns.iter().enumerate() {
             let coltype = column.coltype();
-            for row in rows.iter() {
+            for row in &rows {
                 coltype.write_value(
                     &mut writer,
                     row[index],


### PR DESCRIPTION
This pull request resolves pedantic clippy lints [explicit_iter_loop](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_iter_loop) and [explicit_into_iter_loop](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_into_iter_loop). This is a readability improvement and no functionality is changed.

---

```rust
for x in y.into_iter() {
    // ..
}
```

instead becomes:

```rust
for x in y {
    // ..
}
```

---

```rust
for x in y.iter() {
    // ..
}
```

instead becomes:

```rust
for x in &y {
    // ..
}
```

---

```rust
for x in y.iter_mut() {
    // ..
}
```

instead becomes:

```rust
for x in &mut y {
    // ..
}
```