### PR TITLE
Take small arguments by value instead of by ref

### DIFF
--- a/src/internal/category.rs
+++ b/src/internal/category.rs
@@ -337,8 +337,8 @@ impl Category {
         ]
     }
 
-    pub(crate) fn as_str(&self) -> &'static str {
-        match *self {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
             Category::AnyPath => "AnyPath",
             Category::Binary => "Binary",
             Category::Cabinet => "Cabinet",

--- a/src/internal/codepage.rs
+++ b/src/internal/codepage.rs
@@ -215,8 +215,8 @@ impl CodePage {
         }
     }
 
-    fn encoding(&self) -> &'static Encoding {
-        match *self {
+    fn encoding(self) -> &'static Encoding {
+        match self {
             CodePage::Windows932 => encoding_rs::EUC_JP,
             CodePage::Windows936 => encoding_rs::BIG5,
             CodePage::Windows949 => encoding_rs::EUC_KR,

--- a/src/internal/expr.rs
+++ b/src/internal/expr.rs
@@ -410,8 +410,8 @@ enum UnOp {
 }
 
 impl UnOp {
-    fn eval(&self, arg: Value) -> Value {
-        match *self {
+    fn eval(self, arg: Value) -> Value {
+        match self {
             UnOp::Neg => match arg {
                 Value::Int(number) => Value::Int(-number),
                 _ => Value::Null,
@@ -448,8 +448,8 @@ enum BinOp {
 }
 
 impl BinOp {
-    fn eval(&self, arg1: Value, arg2: Value) -> Value {
-        match *self {
+    fn eval(self, arg1: Value, arg2: Value) -> Value {
+        match self {
             BinOp::Eq => Value::from_bool(arg1 == arg2),
             BinOp::Ne => Value::from_bool(arg1 != arg2),
             BinOp::Lt => Value::from_bool(arg1 < arg2),
@@ -517,8 +517,8 @@ impl BinOp {
         }
     }
 
-    fn precedence(&self) -> i32 {
-        match *self {
+    fn precedence(self) -> i32 {
+        match self {
             BinOp::Eq => 3,
             BinOp::Ne => 3,
             BinOp::Lt => 3,

--- a/src/internal/package.rs
+++ b/src/internal/package.rs
@@ -61,7 +61,7 @@ fn make_validation_columns() -> Vec<Column> {
     let min = -0x7fff_ffff;
     let max = 0x7fff_ffff;
     let values: Vec<&str> =
-        Category::all().iter().map(Category::as_str).collect();
+        Category::all().into_iter().map(Category::as_str).collect();
     vec![
         Column::build("Table").primary_key().id_string(32),
         Column::build("Column").primary_key().id_string(32),
@@ -117,8 +117,8 @@ impl PackageType {
         }
     }
 
-    fn clsid(&self) -> Uuid {
-        match *self {
+    fn clsid(self) -> Uuid {
+        match self {
             PackageType::Installer => {
                 Uuid::parse_str(INSTALLER_PACKAGE_CLSID).unwrap()
             }


### PR DESCRIPTION
This pull request resolves the pedantic clippy lint [trivially_copy_pass_by_ref ](https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref). This is a very minor efficiency improvement and merely allows for better compiler optimisations. None of the affected functions are part of the public API.

On 64-bit systems, a reference is the size of a pointer (`usize`), so 8 bytes. Where an argument's type is `Copy` and less than 8 bytes, it's more efficient to pass it by value. All of the affected arguments (`self`) are 1 byte when passed by value.

[trivially_copy_pass_by_ref ](https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref):

> #### Why is this bad?
>
> In many calling conventions instances of structs will be passed through registers if they fit into two or less general purpose registers.
