### PR TITLE
Add `#[must_use]` to public methods with meaningful return types

### DIFF
--- a/src/internal/category.rs
+++ b/src/internal/category.rs
@@ -370,6 +370,7 @@ impl Category {
 
     /// Returns true if the given string is valid to store in a database column
     /// with this category.
+    #[must_use]
     pub fn validate(&self, string: &str) -> bool {
         match *self {
             Category::Text => true,

--- a/src/internal/codepage.rs
+++ b/src/internal/codepage.rs
@@ -70,6 +70,7 @@ pub enum CodePage {
 
 impl CodePage {
     /// Returns the code page (if any) with the given ID number.
+    #[must_use]
     pub fn from_id(id: i32) -> Option<CodePage> {
         match id {
             0 => Some(CodePage::default()),
@@ -104,6 +105,7 @@ impl CodePage {
     }
 
     /// Returns the ID number used within Windows to represent this code page.
+    #[must_use]
     pub fn id(&self) -> i32 {
         match *self {
             CodePage::Windows932 => 932,
@@ -136,6 +138,7 @@ impl CodePage {
     }
 
     /// Returns a human-readable name for this code page.
+    #[must_use]
     pub fn name(&self) -> &str {
         match *self {
             CodePage::Windows932 => "Windows Japanese Shift JIS",
@@ -170,6 +173,7 @@ impl CodePage {
     /// Decodes a byte array into a string, using this code page.  Invalid
     /// characters will be replaced with a Unicode replacement character
     /// (U+FFFD).
+    #[must_use]
     pub fn decode(&self, bytes: &[u8]) -> String {
         if *self == CodePage::UsAscii {
             ascii_decode(bytes)
@@ -182,6 +186,7 @@ impl CodePage {
     /// non-Unicode code pages, any characters that cannot be represented will
     /// be replaced with a code-page-specific replacement character (typically
     /// `'?'`).
+    #[must_use]
     pub fn encode(&self, string: &str) -> Vec<u8> {
         if *self == CodePage::UsAscii {
             ascii_encode(string)

--- a/src/internal/column.rs
+++ b/src/internal/column.rs
@@ -247,31 +247,37 @@ impl Column {
     }
 
     /// Returns the name of the column.
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.name
     }
 
     /// Returns the type of data stored in the column.
+    #[must_use]
     pub fn coltype(&self) -> ColumnType {
         self.coltype
     }
 
     /// Returns true if values in this column can be localized.
+    #[must_use]
     pub fn is_localizable(&self) -> bool {
         self.is_localizable
     }
 
     /// Returns true if values in this column can be null.
+    #[must_use]
     pub fn is_nullable(&self) -> bool {
         self.is_nullable
     }
 
     /// Returns true if this is primary key column.
+    #[must_use]
     pub fn is_primary_key(&self) -> bool {
         self.is_primary_key
     }
 
     /// Returns the (min, max) integer value range for this column, if any.
+    #[must_use]
     pub fn value_range(&self) -> Option<(i32, i32)> {
         self.value_range
     }
@@ -283,11 +289,13 @@ impl Column {
     }
 
     /// Returns the string value category for this column, if any.
+    #[must_use]
     pub fn category(&self) -> Option<Category> {
         self.category
     }
 
     /// Returns the list of valid enum values for this column, if any.
+    #[must_use]
     pub fn enum_values(&self) -> Option<&[String]> {
         if self.enum_values.is_empty() {
             None
@@ -297,6 +305,7 @@ impl Column {
     }
 
     /// Returns true if the given value is valid for this column.
+    #[must_use]
     pub fn is_valid_value(&self, value: &Value) -> bool {
         match *value {
             Value::Null => self.is_nullable,
@@ -364,30 +373,35 @@ impl ColumnBuilder {
     }
 
     /// Makes the column be localizable.
+    #[must_use]
     pub fn localizable(mut self) -> ColumnBuilder {
         self.is_localizable = true;
         self
     }
 
     /// Makes the column allow null values.
+    #[must_use]
     pub fn nullable(mut self) -> ColumnBuilder {
         self.is_nullable = true;
         self
     }
 
     /// Makes the column be a primary key column.
+    #[must_use]
     pub fn primary_key(mut self) -> ColumnBuilder {
         self.is_primary_key = true;
         self
     }
 
     /// Makes the column only permit values in the given range.
+    #[must_use]
     pub fn range(mut self, min: i32, max: i32) -> ColumnBuilder {
         self.value_range = Some((min, max));
         self
     }
 
     /// Makes the column refer to a key column in another table.
+    #[must_use]
     pub fn foreign_key(
         mut self,
         table_name: &str,
@@ -398,46 +412,54 @@ impl ColumnBuilder {
     }
 
     /// For string columns, makes the column use the specified data format.
+    #[must_use]
     pub fn category(mut self, category: Category) -> ColumnBuilder {
         self.category = Some(category);
         self
     }
 
     /// Makes the column only permit the given values.
+    #[must_use]
     pub fn enum_values(mut self, values: &[&str]) -> ColumnBuilder {
         self.enum_values = values.iter().map(|val| val.to_string()).collect();
         self
     }
 
     /// Builds a column that stores a 16-bit integer.
+    #[must_use]
     pub fn int16(self) -> Column {
         self.with_type(ColumnType::Int16)
     }
 
     /// Builds a column that stores a 32-bit integer.
+    #[must_use]
     pub fn int32(self) -> Column {
         self.with_type(ColumnType::Int32)
     }
 
     /// Builds a column that stores a string.
+    #[must_use]
     pub fn string(self, max_len: usize) -> Column {
         self.with_type(ColumnType::Str(max_len))
     }
 
     /// Builds a column that stores an identifier string.  This is equivalent
     /// to `self.category(Category::Identifier).string(max_len)`.
+    #[must_use]
     pub fn id_string(self, max_len: usize) -> Column {
         self.category(Category::Identifier).string(max_len)
     }
 
     /// Builds a column that stores a text string.  This is equivalent to
     /// `self.category(Category::Text).string(max_len)`.
+    #[must_use]
     pub fn text_string(self, max_len: usize) -> Column {
         self.category(Category::Text).string(max_len)
     }
 
     /// Builds a column that stores a formatted string.  This is equivalent to
     /// `self.category(Category::Formatted).string(max_len)`.
+    #[must_use]
     pub fn formatted_string(self, max_len: usize) -> Column {
         self.category(Category::Formatted).string(max_len)
     }
@@ -445,6 +467,7 @@ impl ColumnBuilder {
     /// Builds a column that refers to a binary data stream.  This sets the
     /// category to `Category::Binary` in addition to setting the column
     /// type.
+    #[must_use]
     pub fn binary(self) -> Column {
         self.category(Category::Binary).string(0)
     }

--- a/src/internal/expr.rs
+++ b/src/internal/expr.rs
@@ -40,16 +40,19 @@ impl Expr {
     }
 
     /// Returns an expression that evaluates to a null value.
+    #[must_use]
     pub fn null() -> Expr {
         Expr { ast: Ast::Literal(Value::Null) }
     }
 
     /// Returns an expression that evaluates to the given boolean value.
+    #[must_use]
     pub fn boolean(boolean: bool) -> Expr {
         Expr { ast: Ast::Literal(Value::from_bool(boolean)) }
     }
 
     /// Returns an expression that evaluates to the given integer value.
+    #[must_use]
     pub fn integer(integer: i32) -> Expr {
         Expr { ast: Ast::Literal(Value::Int(integer)) }
     }
@@ -61,12 +64,14 @@ impl Expr {
 
     /// Returns an expression that evaluates to true if the two subexpressions
     /// evaluate to equal values.
+    #[must_use]
     pub fn eq(self, rhs: Expr) -> Expr {
         Expr::binop(BinOp::Eq, self.ast, rhs.ast)
     }
 
     /// Returns an expression that evaluates to true if the two subexpressions
     /// evaluate to unequal values.
+    #[must_use]
     pub fn ne(self, rhs: Expr) -> Expr {
         Expr::binop(BinOp::Ne, self.ast, rhs.ast)
     }
@@ -74,6 +79,7 @@ impl Expr {
     /// Returns an expression that evaluates to true if the left-hand
     /// subexpression evaluates to a strictly lesser value than the right-hand
     /// subexpression.
+    #[must_use]
     pub fn lt(self, rhs: Expr) -> Expr {
         Expr::binop(BinOp::Lt, self.ast, rhs.ast)
     }
@@ -81,6 +87,7 @@ impl Expr {
     /// Returns an expression that evaluates to true if the left-hand
     /// subexpression evaluates to a lesser-or-equal value than the right-hand
     /// subexpression.
+    #[must_use]
     pub fn le(self, rhs: Expr) -> Expr {
         Expr::binop(BinOp::Le, self.ast, rhs.ast)
     }
@@ -88,6 +95,7 @@ impl Expr {
     /// Returns an expression that evaluates to true if the left-hand
     /// subexpression evaluates to a strictly greater value than the right-hand
     /// subexpression.
+    #[must_use]
     pub fn gt(self, rhs: Expr) -> Expr {
         Expr::binop(BinOp::Gt, self.ast, rhs.ast)
     }
@@ -95,6 +103,7 @@ impl Expr {
     /// Returns an expression that evaluates to true if the left-hand
     /// subexpression evaluates to a greater-or-equal value than the right-hand
     /// subexpression.
+    #[must_use]
     pub fn ge(self, rhs: Expr) -> Expr {
         Expr::binop(BinOp::Ge, self.ast, rhs.ast)
     }
@@ -105,18 +114,21 @@ impl Expr {
     ///
     /// This method exists instead of the `std::ops::Not` trait to distinguish
     /// it from the (logical) `not()` method.
+    #[must_use]
     pub fn bitinv(self) -> Expr {
         Expr::unop(UnOp::BitNot, self.ast)
     }
 
     /// Returns an expression that evaluates to true if both subexpressions
     /// evaluate to true.
+    #[must_use]
     pub fn and(self, rhs: Expr) -> Expr {
         Expr { ast: Ast::And(Box::new(self.ast), Box::new(rhs.ast)) }
     }
 
     /// Returns an expression that evaluates to true if either subexpression
     /// evaluates to true.
+    #[must_use]
     pub fn or(self, rhs: Expr) -> Expr {
         Expr { ast: Ast::Or(Box::new(self.ast), Box::new(rhs.ast)) }
     }
@@ -126,6 +138,7 @@ impl Expr {
     ///
     /// This method exists instead of the `std::ops::Not` trait to distinguish
     /// it from the (bitwise) `bitinv()` method.
+    #[must_use]
     pub fn not(self) -> Expr {
         Expr::unop(UnOp::BoolNot, self.ast)
     }
@@ -133,11 +146,13 @@ impl Expr {
     /// Evaluates the expression against the given row.  Any errors in the
     /// expression (such as dividing a number by zero, or applying a bitwise
     /// operator to a string) will result in a null value.
+    #[must_use]
     pub fn eval(&self, row: &Row) -> Value {
         self.ast.eval(row)
     }
 
     /// Returns the set of all column names referenced by this expression.
+    #[must_use]
     pub fn column_names(&self) -> HashSet<&str> {
         let mut names = HashSet::new();
         self.ast.populate_column_names(&mut names);

--- a/src/internal/language.rs
+++ b/src/internal/language.rs
@@ -34,6 +34,7 @@ impl Language {
     /// assert_eq!(msi::Language::from_code(1033).code(), 1033);
     /// assert_eq!(msi::Language::from_code(3084).code(), 3084);
     /// ```
+    #[must_use]
     pub fn from_code(code: u16) -> Language {
         Language { code }
     }
@@ -47,6 +48,7 @@ impl Language {
     /// assert_eq!(msi::Language::from_tag("en-US").tag(), "en-US");
     /// assert_eq!(msi::Language::from_tag("fr-CA").tag(), "fr-CA");
     /// ```
+    #[must_use]
     pub fn from_tag(tag: &str) -> Language {
         let parts: Vec<&str> = tag.splitn(2, '-').collect();
         for &(lang_code, lang_tag, sublangs) in LANGUAGES {
@@ -78,6 +80,7 @@ impl Language {
     /// assert_eq!(msi::Language::from_tag("en-US").code(), 1033);
     /// assert_eq!(msi::Language::from_tag("fr-CA").code(), 3084);
     /// ```
+    #[must_use]
     pub fn code(&self) -> u16 {
         self.code
     }
@@ -94,6 +97,7 @@ impl Language {
     /// assert_eq!(msi::Language::from_code(3084).tag(), "fr-CA");
     /// assert_eq!(msi::Language::from_code(65535).tag(), "und");
     /// ```
+    #[must_use]
     pub fn tag(&self) -> &str {
         let lang_code = self.code & LANG_MASK;
         match LANGUAGES.binary_search_by_key(&lang_code, |t| t.0) {

--- a/src/internal/package.rs
+++ b/src/internal/package.rs
@@ -201,21 +201,25 @@ pub struct Package<F> {
 
 impl<F> Package<F> {
     /// Returns what type of package this is.
+    #[must_use]
     pub fn package_type(&self) -> PackageType {
         self.package_type
     }
 
     /// Returns summary information for this package.
+    #[must_use]
     pub fn summary_info(&self) -> &SummaryInfo {
         &self.summary_info
     }
 
     /// Returns the code page used for serializing strings in the database.
+    #[must_use]
     pub fn database_codepage(&self) -> CodePage {
         self.string_pool.codepage()
     }
 
     /// Returns true if the database has a table with the given name.
+    #[must_use]
     pub fn has_table(&self, table_name: &str) -> bool {
         self.tables.contains_key(table_name)
     }
@@ -226,17 +230,20 @@ impl<F> Package<F> {
     }
 
     /// Returns an iterator over the database tables in this package.
+    #[must_use]
     pub fn tables(&self) -> Tables {
         Tables { iter: self.tables.values() }
     }
 
     /// Returns true if the package has an embedded binary stream with the
     /// given name.
+    #[must_use]
     pub fn has_stream(&self, stream_name: &str) -> bool {
         self.comp().is_stream(streamname::encode(stream_name, false))
     }
 
     /// Returns an iterator over the embedded binary streams in this package.
+    #[must_use]
     pub fn streams(&self) -> Streams<F> {
         Streams::new(self.comp().read_root_storage())
     }
@@ -244,6 +251,7 @@ impl<F> Package<F> {
     /// Returns true if the package has been digitally signed.  Note that this
     /// method only checks whether a signature is present; it does *not* verify
     /// that the signature is actually valid.
+    #[must_use]
     pub fn has_digital_signature(&self) -> bool {
         self.comp().is_stream(DIGITAL_SIGNATURE_STREAM_NAME)
     }

--- a/src/internal/query.rs
+++ b/src/internal/query.rs
@@ -26,6 +26,7 @@ impl Delete {
     /// rows that match the given boolean expression will be deleted.  (This
     /// method would have been called `where()`, to better match SQL, but
     /// `where` is a reserved word in Rust.)
+    #[must_use]
     pub fn with(mut self, condition: Expr) -> Delete {
         self.condition = if let Some(expr) = self.condition {
             Some(expr.and(condition))
@@ -125,12 +126,14 @@ impl Insert {
     }
 
     /// Adds a new row to be inserted into the table.
+    #[must_use]
     pub fn row(mut self, values: Vec<Value>) -> Insert {
         self.new_rows.push(values);
         self
     }
 
     /// Adds multiple new rows to be inserted into the table.
+    #[must_use]
     pub fn rows(mut self, mut rows: Vec<Vec<Value>>) -> Insert {
         self.new_rows.append(&mut rows);
         self
@@ -446,6 +449,7 @@ impl Select {
 
     /// Performs an inner join between this and another query, producing a row
     /// for each pair of rows from the two tables that matches the expression.
+    #[must_use]
     pub fn inner_join(self, rhs: Select, on: Expr) -> Select {
         Select {
             from: Join::Inner(Box::new(self), Box::new(rhs), on),
@@ -455,6 +459,7 @@ impl Select {
     }
 
     /// Performs a left join between this and another query.
+    #[must_use]
     pub fn left_join(self, rhs: Select, on: Expr) -> Select {
         Select {
             from: Join::Left(Box::new(self), Box::new(rhs), on),
@@ -467,6 +472,7 @@ impl Select {
 
     /// Transforms the selected rows to only include the specified columns, in
     /// the order given.
+    #[must_use]
     pub fn columns<S>(mut self, column_names: &[S]) -> Select
     where
         S: Clone + Into<String>,
@@ -480,6 +486,7 @@ impl Select {
     /// rows that match the given boolean expression will be returned.  (This
     /// method would have been called `where()`, to better match SQL, but
     /// `where` is a reserved word in Rust.)
+    #[must_use]
     pub fn with(mut self, condition: Expr) -> Select {
         self.condition = if let Some(expr) = self.condition {
             Some(expr.and(condition))
@@ -619,6 +626,7 @@ impl Update {
     }
 
     /// Adds a column value to be set by the query.
+    #[must_use]
     pub fn set<S: Into<String>>(
         mut self,
         column_name: S,
@@ -632,6 +640,7 @@ impl Update {
     /// rows that match the given boolean expression will be updated.  (This
     /// method would have been called `where()`, to better match SQL, but
     /// `where` is a reserved word in Rust.)
+    #[must_use]
     pub fn with(mut self, condition: Expr) -> Update {
         self.condition = if let Some(expr) = self.condition {
             Some(expr.and(condition))

--- a/src/internal/summary.rs
+++ b/src/internal/summary.rs
@@ -60,6 +60,7 @@ impl SummaryInfo {
     /// Gets the architecture string from the "template" property, if one is
     /// set.  This indicates the hardware architecture that this package is
     /// intended for (e.g. `"x64"`).
+    #[must_use]
     pub fn arch(&self) -> Option<&str> {
         match self.properties.get(PROPERTY_TEMPLATE) {
             Some(PropertyValue::LpStr(template)) => {
@@ -99,6 +100,7 @@ impl SummaryInfo {
 
     /// Gets the "author" property, if one is set.  This indicates the name of
     /// the person or company that created the package.
+    #[must_use]
     pub fn author(&self) -> Option<&str> {
         match self.properties.get(PROPERTY_AUTHOR) {
             Some(PropertyValue::LpStr(author)) => Some(author.as_str()),
@@ -118,6 +120,7 @@ impl SummaryInfo {
     }
 
     /// Gets the code page used for serializing this summary info.
+    #[must_use]
     pub fn codepage(&self) -> CodePage {
         self.properties.codepage()
     }
@@ -130,6 +133,7 @@ impl SummaryInfo {
     /// Gets the "comments" property, if one is set.  This typically gives a
     /// brief description of the application/software that will be installed by
     /// the package.
+    #[must_use]
     pub fn comments(&self) -> Option<&str> {
         match self.properties.get(PROPERTY_COMMENTS) {
             Some(PropertyValue::LpStr(comments)) => Some(comments.as_str()),
@@ -151,6 +155,7 @@ impl SummaryInfo {
     /// Gets the "creating application" property, if one is set.  This
     /// indicates the name of the software application/tool that was used to
     /// create the package.
+    #[must_use]
     pub fn creating_application(&self) -> Option<&str> {
         match self.properties.get(PROPERTY_CREATING_APP) {
             Some(PropertyValue::LpStr(app_name)) => Some(app_name.as_str()),
@@ -171,6 +176,7 @@ impl SummaryInfo {
 
     /// Gets the "creation time" property, if one is set.  This indicates the
     /// date/time when the package was created.
+    #[must_use]
     pub fn creation_time(&self) -> Option<SystemTime> {
         match self.properties.get(PROPERTY_CREATION_TIME) {
             Some(&PropertyValue::FileTime(timestamp)) => {
@@ -248,6 +254,7 @@ impl SummaryInfo {
     /// Gets the "subject" property, if one is set.  This typically indicates
     /// the name of the application/software that will be installed by the
     /// package.
+    #[must_use]
     pub fn subject(&self) -> Option<&str> {
         match self.properties.get(PROPERTY_SUBJECT) {
             Some(PropertyValue::LpStr(subject)) => Some(subject.as_str()),
@@ -268,6 +275,7 @@ impl SummaryInfo {
 
     /// Gets the "title" property, if one is set.  This indicates the type of
     /// the installer package (e.g. "Installation Database" or "Patch").
+    #[must_use]
     pub fn title(&self) -> Option<&str> {
         match self.properties.get(PROPERTY_TITLE) {
             Some(PropertyValue::LpStr(title)) => Some(title.as_str()),
@@ -287,6 +295,7 @@ impl SummaryInfo {
     }
 
     /// Gets the "UUID" property, if one is set.
+    #[must_use]
     pub fn uuid(&self) -> Option<Uuid> {
         match self.properties.get(PROPERTY_UUID) {
             Some(PropertyValue::LpStr(string)) => {
@@ -311,6 +320,7 @@ impl SummaryInfo {
     }
 
     /// Gets the "Word Count" property, if one is set.
+    #[must_use]
     pub fn word_count(&self) -> Option<i32> {
         match self.properties.get(PROPERTY_WORD_COUNT) {
             Some(PropertyValue::I4(word_count)) => Some(*word_count),

--- a/src/internal/table.rs
+++ b/src/internal/table.rs
@@ -30,6 +30,7 @@ impl Table {
     }
 
     /// Returns the name of the table.
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -49,16 +50,19 @@ impl Table {
     }
 
     /// Returns the list of columns in this table.
+    #[must_use]
     pub fn columns(&self) -> &[Column] {
         &self.columns
     }
 
     /// Returns true if this table has a column with the given name.
+    #[must_use]
     pub fn has_column(&self, column_name: &str) -> bool {
         self.index_for_column_name(column_name).is_some()
     }
 
     /// Returns the column with the given name, if any.
+    #[must_use]
     pub fn get_column(&self, column_name: &str) -> Option<&Column> {
         match self.index_for_column_name(column_name) {
             Some(index) => Some(&self.columns[index]),
@@ -67,6 +71,7 @@ impl Table {
     }
 
     /// Returns the indices of table's primary key columns.
+    #[must_use]
     pub fn primary_key_indices(&self) -> Vec<usize> {
         self.columns
             .iter()
@@ -165,21 +170,25 @@ impl Row {
     }
 
     /// Returns the number of values in the row.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.values.len()
     }
 
     /// Returns values in the row is empty
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Returns the list of columns in this row.
+    #[must_use]
     pub fn columns(&self) -> &[Column] {
         self.table.columns()
     }
 
     /// Returns true if this row has a column with the given name.
+    #[must_use]
     pub fn has_column(&self, column_name: &str) -> bool {
         self.table.has_column(column_name)
     }
@@ -253,6 +262,7 @@ impl<'a> Rows<'a> {
     }
 
     /// Returns the list of columns for these rows.
+    #[must_use]
     pub fn columns(&self) -> &[Column] {
         self.table.columns()
     }

--- a/src/internal/value.rs
+++ b/src/internal/value.rs
@@ -19,16 +19,19 @@ pub enum Value {
 
 impl Value {
     /// Returns true if this is a null value.
+    #[must_use]
     pub fn is_null(&self) -> bool {
         matches!(*self, Value::Null)
     }
 
     /// Returns true if this is an integer value.
+    #[must_use]
     pub fn is_int(&self) -> bool {
         matches!(*self, Value::Int(_))
     }
 
     /// Extracts the integer value if it is an integer.
+    #[must_use]
     pub fn as_int(&self) -> Option<i32> {
         match *self {
             Value::Null => None,
@@ -38,11 +41,13 @@ impl Value {
     }
 
     /// Returns true if this is a string value.
+    #[must_use]
     pub fn is_str(&self) -> bool {
         matches!(*self, Value::Str(_))
     }
 
     /// Extracts the string value if it is a string.
+    #[must_use]
     pub fn as_str(&self) -> Option<&str> {
         match *self {
             Value::Null => None,


### PR DESCRIPTION
This pull request adds `#[must_use]` to public methods to resolve the pedantic clippy lint [must_use_candidate](https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate). The [`#[must_use]`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute) attribute generates a diagnostic warning when a value is not used.

For example, currently if a user does:

```rust
package.summary_info();
```

They won't get any warning despite it being obviously unintentional as this method is not a unit and has a meaningful return type. 

With this PR, when a user does do that, they will get a diagnostic warning.