### PR TITLE
Add zh-CN language tag

### DIFF
--- a/src/internal/language.rs
+++ b/src/internal/language.rs
@@ -143,7 +143,11 @@ const LANGUAGES: &[(u16, &str, &[SubLanguage])] = &[
     ),
     (0x02, "bg", &[(0x01, "bg-BG")]),
     (0x03, "ca", &[(0x01, "ca-ES")]),
-    (0x04, "zh", &[(0x03, "zh-HK"), (0x04, "zh-SG"), (0x05, "zh-MO")]),
+    (
+        0x04,
+        "zh",
+        &[(0x02, "zh-CN"), (0x03, "zh-HK"), (0x04, "zh-SG"), (0x05, "zh-MO")],
+    ),
     (0x05, "cs", &[(0x01, "cs-CZ")]),
     (0x06, "da", &[(0x01, "da-DK")]),
     (


### PR DESCRIPTION
I found this out from investigating https://github.com/vedantmgoyal9/winget-releaser/issues/330; the language tag for `zh-CN` ([2052](https://learn.microsoft.com/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a)) was missing.

```math
\begin{aligned}
2052 \;\&\; 0x3FF &= 4 \\
2052 \gg 10 &= 2
\end{aligned}
```
