### PR TITLE
Fix incorrect encoding mappings for CP932 and CP936

### DIFF
--- a/src/internal/codepage.rs
+++ b/src/internal/codepage.rs
@@ -222,8 +222,8 @@ impl CodePage {
 
     fn encoding(self) -> &'static Encoding {
         match self {
-            CodePage::Windows932 => encoding_rs::EUC_JP,
-            CodePage::Windows936 => encoding_rs::BIG5,
+            CodePage::Windows932 => encoding_rs::SHIFT_JIS,
+            CodePage::Windows936 => encoding_rs::GBK,
             CodePage::Windows949 => encoding_rs::EUC_KR,
             CodePage::Windows950 | CodePage::Windows951 => encoding_rs::BIG5,
             CodePage::Windows1250 => encoding_rs::WINDOWS_1250,


### PR DESCRIPTION
### Summary

- Fix CP932 (Windows Japanese) mapping from `EUC_JP` to `SHIFT_JIS` - these are two distinct Japanese encodings with incompatible byte sequences
- Fix CP936 (Windows Chinese Simplified) mapping from `BIG5` to `GBK` - Big5 is Traditional Chinese (CP950), while GBK is Simplified Chinese

### Details

The `encoding()` method in `codepage.rs` had two incorrect mappings that would cause data corruption when decoding/encoding strings in MSI files using these code pages:

| Code Page            | Before (wrong)         | After (correct)          |
|---------------------|------------------------|--------------------------|
| CP932 (Shift_JIS)   | `encoding_rs::EUC_JP`  | `encoding_rs::SHIFT_JIS` |
| CP936 (GBK)         | `encoding_rs::BIG5`    | `encoding_rs::GBK`       |
