### PR TITLE
Fix error on column field size of 0

### DIFF
--- a/src/internal/column.rs
+++ b/src/internal/column.rs
@@ -36,7 +36,6 @@ pub enum ColumnType {
 }
 
 impl ColumnType {
-    #[allow(clippy::if_same_then_else)]
     fn from_bitfield(type_bits: i32) -> io::Result<ColumnType> {
         let field_size = (type_bits & COL_FIELD_SIZE_MASK) as usize;
         if (type_bits & !COL_NULLABLE_BIT) == (COL_STRING_BIT | COL_VALID_BIT)
@@ -44,24 +43,27 @@ impl ColumnType {
             Ok(ColumnType::Binary)
         } else if (type_bits & COL_STRING_BIT) != 0 {
             Ok(ColumnType::Str(field_size))
-        } else if field_size == 4 {
-            if (type_bits & COL_NONBINARY_BIT) == 0 {
-                Ok(ColumnType::Int32)
-            } else {
-                Ok(ColumnType::Binary)
-            }
-        } else if field_size == 2 {
-            Ok(ColumnType::Int16)
-        } else if field_size == 1 {
-            // Some implementations seem to set the integer field size to 1 for
-            // certain columns, but still store the data with 2 bytes?  See
-            // https://github.com/mdsteele/rust-msi/issues/8.
-            Ok(ColumnType::Int16)
         } else {
-            invalid_data!(
-                "Invalid field size for integer column ({})",
-                field_size
-            );
+            match field_size {
+                4 => {
+                    if (type_bits & COL_NONBINARY_BIT) == 0 {
+                        Ok(ColumnType::Int32)
+                    } else {
+                        Ok(ColumnType::Binary)
+                    }
+                }
+                0..=2 => {
+                    // Fields sizes less than 2 still store the data with 2 bytes.
+                    // See:
+                    // - https://github.com/mdsteele/rust-msi/issues/8
+                    // - https://github.com/mdsteele/rust-msi/issues/50
+                    Ok(ColumnType::Int16)
+                }
+                _ => invalid_data!(
+                    "Invalid field size for integer column ({})",
+                    field_size
+                ),
+            }
         }
     }
 

--- a/src/internal/table.rs
+++ b/src/internal/table.rs
@@ -112,8 +112,7 @@ impl Table {
             .map(|col| col.coltype().width(self.long_string_refs))
             .sum::<u64>();
         let num_columns = self.columns.len();
-        let num_rows =
-            if row_size > 0 { (data_length / row_size) as usize } else { 0 };
+        let num_rows = data_length.checked_div(row_size).unwrap_or_default();
         // The number of rows cannot exceed 65536, according to this FAQ:
         // http://www.installsite.org/pages/en/msifaq/a/1043.htm
         if num_rows > 65536 {
@@ -122,8 +121,10 @@ impl Table {
                 num_rows
             );
         }
-        let mut rows =
-            vec![Vec::<ValueRef>::with_capacity(num_columns); num_rows];
+        let mut rows = vec![
+            Vec::<ValueRef>::with_capacity(num_columns);
+            num_rows as usize
+        ];
         for column in &self.columns {
             let coltype = column.coltype();
             for row in &mut rows {


### PR DESCRIPTION
This pull request fixes the error `Invalid field size for integer column (0)` when there is a column field size of 0. The file used for testing was https://cdn.zabbix.com/zabbix/binaries/stable/7.4/7.4.8/zabbix_agent2-7.4.8-windows-amd64-openssl.msi.

The column that causes this issue is `ReturnCode` in the `Win32_Execute` table. Whilst Orca outputs this as an [`I0`](https://learn.microsoft.com/windows/win32/msi/column-definition-format), [lessmsi](https://github.com/activescott/lessmsi) treats this column as an [`I2`](https://learn.microsoft.com/windows/win32/msi/column-definition-format). The code has been updated to also treat it as an `I2`.

#### Orca table export

```
Id	ComponentId	Condition	Directory	CommandLine	ErrorMessage	ReturnCode	Attributes
s72	S72	S0	S0	s0	S255	I0	I2
Win32_Execute	Id
```

#### lessmsi

<img width="876" height="98" alt="{030D52DB-30BB-4A8B-B05B-BBDA63F4DAFC}" src="https://github.com/user-attachments/assets/baa94a00-d64f-4093-a1a6-7903bc4f4610" />

---

This mirrors how we deal with a field size of 1. In the same file, the `Protocol` field in the `WixFirewallException` table has a size of 1, which is reflected in the Orca table export as an [`I1`](https://learn.microsoft.com/windows/win32/msi/column-definition-format), but like [this crate](https://github.com/mdsteele/rust-msi/blob/88a828be577395fd1eba82884cc803c79b0ec9aa/src/internal/column.rs#L59), lessmsi treats it as an [`I2`](https://learn.microsoft.com/windows/win32/msi/column-definition-format).

#### Orca table export

```
WixFirewallException	Name	RemoteAddresses	Port	Protocol	Program	Attributes	Profile	Component_	Description
s72	L255	s0	S0	I1	S255	I4	i4	s72	S255
WixFirewallException	WixFirewallException
fwException	Zabbix Agent 2 listen port	*	[ListenPortFW]	6	[#ZABBIX_AGENT.EXE]	0	2147483647	CONFIGFWx64	Zabbix Agent 2 will listen on this port for connections from the server.
fwExceptionW2k3	Zabbix Agent 2 listen port	*	[ListenPortFW]	6		0	2147483647	CONFIGFWx64W2k3	Zabbix Agent 2 will listen on this port for connections from the server.
```

#### lessmsi

<img width="1454" height="144" alt="{00CCCEE8-879E-4927-9D83-E72317CEB4FA}" src="https://github.com/user-attachments/assets/12a4db09-c725-4abb-a417-a3614b970780" />

---

This pull request also resolves the clippy lint [manual_checked_ops](https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#manual_checked_ops) introduced in Rust 1.95.0.

---

- Resolves #50