### PR TITLE
Migrate to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/mdsteele/rust-msi"
 keywords = ["msi", "windows", "installer", "package"]
 license = "MIT"
 readme = "README.md"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 
 [package]
 name = "msi"
@@ -21,6 +22,7 @@ keywords.workspace = true
 license.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 byteorder = "1"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -8,6 +8,7 @@ keywords.workspace = true
 license.workspace = true
 readme.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "msi_ffi"

--- a/src/internal/expr.rs
+++ b/src/internal/expr.rs
@@ -339,9 +339,9 @@ impl Ast {
         parent_prec: i32,
     ) -> Result<(), fmt::Error> {
         match self {
-            Ast::Literal(ref value) => fmt::Display::fmt(value, formatter),
-            Ast::Column(ref name) => formatter.write_str(name.as_str()),
-            Ast::UnOp(op, ref arg) => {
+            Ast::Literal(value) => fmt::Display::fmt(value, formatter),
+            Ast::Column(name) => formatter.write_str(name.as_str()),
+            Ast::UnOp(op, arg) => {
                 match op {
                     UnOp::Neg => formatter.write_str("-")?,
                     UnOp::BitNot => formatter.write_str("~")?,
@@ -349,7 +349,7 @@ impl Ast {
                 }
                 arg.format_with_precedence(formatter, 10)
             }
-            Ast::BinOp(op, ref arg1, ref arg2) => {
+            Ast::BinOp(op, arg1, arg2) => {
                 let op_prec = op.precedence();
                 if op_prec < parent_prec {
                     formatter.write_str("(")?;
@@ -378,7 +378,7 @@ impl Ast {
                 }
                 Ok(())
             }
-            Ast::And(ref arg1, ref arg2) => {
+            Ast::And(arg1, arg2) => {
                 let op_prec = 2;
                 if op_prec < parent_prec {
                     formatter.write_str("(")?;
@@ -391,7 +391,7 @@ impl Ast {
                 }
                 Ok(())
             }
-            Ast::Or(ref arg1, ref arg2) => {
+            Ast::Or(arg1, arg2) => {
                 let op_prec = 1;
                 if op_prec < parent_prec {
                     formatter.write_str("(")?;

--- a/src/internal/package.rs
+++ b/src/internal/package.rs
@@ -14,7 +14,7 @@ use crate::internal::table::{Rows, Table};
 use crate::internal::value::{Value, ValueRef};
 use cfb;
 use std::borrow::Borrow;
-use std::collections::{btree_map, BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, btree_map};
 use std::io::{self, Read, Seek, Write};
 use std::rc::Rc;
 use uuid::Uuid;

--- a/src/internal/propset.rs
+++ b/src/internal/propset.rs
@@ -118,7 +118,7 @@ impl PropertyValue {
                 writer.write_u32::<LittleEndian>(3)?;
                 writer.write_i32::<LittleEndian>(*value)?;
             }
-            PropertyValue::LpStr(ref string) => {
+            PropertyValue::LpStr(string) => {
                 writer.write_u32::<LittleEndian>(30)?;
                 let bytes = codepage.encode(string.as_str());
                 let length = (bytes.len() + 1) as u32;
@@ -147,7 +147,7 @@ impl PropertyValue {
             PropertyValue::I1(_) => 8,
             PropertyValue::I2(_) => 8,
             PropertyValue::I4(_) => 8,
-            PropertyValue::LpStr(ref string) => {
+            PropertyValue::LpStr(string) => {
                 ((12 + string.len() as u32) >> 2) << 2
             }
             PropertyValue::FileTime(_) => 12,

--- a/src/internal/query.rs
+++ b/src/internal/query.rs
@@ -407,8 +407,8 @@ impl Join {
 impl fmt::Display for Join {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
-            Join::Table(ref table_name) => table_name.fmt(formatter),
-            Join::Inner(ref lhs, ref rhs, ref on) => {
+            Join::Table(table_name) => table_name.fmt(formatter),
+            Join::Inner(lhs, rhs, on) => {
                 lhs.format_for_join(formatter)?;
                 formatter.write_str(" INNER JOIN ")?;
                 rhs.format_for_join(formatter)?;
@@ -416,7 +416,7 @@ impl fmt::Display for Join {
                 on.fmt(formatter)?;
                 Ok(())
             }
-            Join::Left(ref lhs, ref rhs, ref on) => {
+            Join::Left(lhs, rhs, on) => {
                 lhs.format_for_join(formatter)?;
                 formatter.write_str(" LEFT JOIN ")?;
                 rhs.format_for_join(formatter)?;

--- a/src/internal/stringpool.rs
+++ b/src/internal/stringpool.rs
@@ -198,11 +198,7 @@ impl StringPool {
     #[allow(dead_code)]
     pub fn refcount(&self, string_ref: StringRef) -> u16 {
         let index = string_ref.index();
-        if index < self.strings.len() {
-            self.strings[index].1
-        } else {
-            0
-        }
+        if index < self.strings.len() { self.strings[index].1 } else { 0 }
     }
 
     /// Inserts a string into the pool, or increments its refcount if it's

--- a/src/internal/summary.rs
+++ b/src/internal/summary.rs
@@ -73,11 +73,7 @@ impl SummaryInfo {
             Some(PropertyValue::LpStr(template)) => {
                 let arch =
                     template.split_once(';').map_or(&**template, |x| x.0);
-                if arch.is_empty() {
-                    None
-                } else {
-                    Some(arch)
-                }
+                if arch.is_empty() { None } else { Some(arch) }
             }
             _ => None,
         }

--- a/src/internal/table.rs
+++ b/src/internal/table.rs
@@ -77,11 +77,7 @@ impl Table {
             .iter()
             .enumerate()
             .filter_map(|(index, column)| {
-                if column.is_primary_key() {
-                    Some(index)
-                } else {
-                    None
-                }
+                if column.is_primary_key() { Some(index) } else { None }
             })
             .collect()
     }
@@ -320,7 +316,7 @@ impl<'a> ExactSizeIterator for Rows<'a> {}
 
 #[cfg(test)]
 mod tests {
-    use crate::{internal::value::ValueRef, Column};
+    use crate::{Column, internal::value::ValueRef};
 
     use super::Table;
 

--- a/src/internal/timestamp.rs
+++ b/src/internal/timestamp.rs
@@ -90,9 +90,9 @@ fn timestamp_delta_to_duration(delta: u64) -> Duration {
 #[cfg(test)]
 mod tests {
     use super::{
-        duration_to_timestamp_delta, system_time_from_timestamp,
-        timestamp_delta_to_duration, timestamp_from_system_time,
-        UNIX_EPOCH_TIMESTAMP,
+        UNIX_EPOCH_TIMESTAMP, duration_to_timestamp_delta,
+        system_time_from_timestamp, timestamp_delta_to_duration,
+        timestamp_from_system_time,
     };
     use std::time::{Duration, UNIX_EPOCH};
 

--- a/src/internal/value.rs
+++ b/src/internal/value.rs
@@ -58,11 +58,7 @@ impl Value {
 
     /// Creates a boolean value.
     pub(crate) fn from_bool(boolean: bool) -> Value {
-        if boolean {
-            Value::Int(1)
-        } else {
-            Value::Int(0)
-        }
+        if boolean { Value::Int(1) } else { Value::Int(0) }
     }
 
     /// Coerces the `Value` to a boolean.  Returns false for null, zero, and

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -41,10 +41,12 @@ fn int_column_value_range() {
 fn string_column_category() {
     let cursor = Cursor::new(Vec::new());
     let mut package = Package::create(PackageType::Installer, cursor).unwrap();
-    let columns = vec![Column::build("Property")
-        .primary_key()
-        .category(Category::Property)
-        .string(32)];
+    let columns = vec![
+        Column::build("Property")
+            .primary_key()
+            .category(Category::Property)
+            .string(32),
+    ];
     package.create_table("Properties", columns).unwrap();
 
     let cursor = package.into_inner().unwrap();
@@ -68,10 +70,12 @@ fn string_column_category() {
 fn string_column_enum_values() {
     let cursor = Cursor::new(Vec::new());
     let mut package = Package::create(PackageType::Installer, cursor).unwrap();
-    let columns = vec![Column::build("Day")
-        .primary_key()
-        .enum_values(&["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"])
-        .string(3)];
+    let columns = vec![
+        Column::build("Day")
+            .primary_key()
+            .enum_values(&["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"])
+            .string(3),
+    ];
     package.create_table("Days", columns).unwrap();
 
     let cursor = package.into_inner().unwrap();


### PR DESCRIPTION
This pull request migrates `msi` to use Rust 2024 edition.

Since Rust 2024 edition was stabilised with Rust 1.85, this specifies an MSRV of 1.85. Previously, the `msi` crate did not make any guarantees around MSRV. However, by using [`cargo-msrv`](https://github.com/foresterre/cargo-msrv), I found this to be Rust 1.78. Rust 1.85 was released on the 20th February 2025.

Migration followed the steps in [Transitioning an existing project to a new edition](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html#transitioning-an-existing-project-to-a-new-edition)