### PR TITLE
Refactor `Language`

### DIFF
--- a/examples/msiinfo.rs
+++ b/examples/msiinfo.rs
@@ -35,7 +35,7 @@ fn print_summary_info<F>(package: &msi::Package<F>) {
     let languages = summary_info.languages();
     if !languages.is_empty() {
         let tags: Vec<&str> =
-            languages.iter().map(msi::Language::tag).collect();
+            languages.iter().map(msi::LanguageId::tag).collect();
         println!("    Language: {}", tags.join(", "));
     }
     if let Some(timestamp) = summary_info.creation_time() {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -112,7 +112,7 @@ fn get_information(path: char_p::Ref<'_>) -> MsiInformation {
                 languages: {
                     let mut langs: Vec<repr_c::String> = Vec::new();
                     for language in package.summary_info().languages() {
-                        langs.push(language.code().to_string().into());
+                        langs.push(language.id().to_string().into());
                     }
                     langs.into()
                 },

--- a/src/internal/language.rs
+++ b/src/internal/language.rs
@@ -1,336 +1,668 @@
-// ========================================================================= //
+use std::fmt;
 
 const LANG_MASK: u16 = 0x3ff;
-const SUBLANG_SHIFT: i32 = 10;
+const SUBLANG_SHIFT: u8 = 10;
 
 const LANG_NEUTRAL: u16 = 0x0;
 const SUBLANG_NEUTRAL: u16 = 0x0;
-const SUBLANG_CUSTOM_UNSPECIFIED: u16 = 0x4;
 
-// ========================================================================= //
-
-/// Represents a particular language/dialect.
+/// Represents a Windows language identifier.
 ///
-/// `Language` values can be passed to `Value::from()` to produce a column
+/// A language identifier is a standard international numeric abbreviation for
+/// the [language] in a country or geographical region. Each language has a
+/// unique language identifier (data type `LANGID`), a 16-bit value that
+/// consists  of a primary language identifier and a sub-language identifier.
+/// For details of language identifiers, see
+/// [Language Identifier Constants and Strings].
+///
+/// A [`LanguageId`] can be passed to [`Value::from()`] to produce a column
 /// value that can be stored in a column with the `Language` category.
+///
+/// [language]: https://learn.microsoft.com/windows/win32/intl/locales-and-languages
+/// [Language Identifier Constants and Strings]: https://learn.microsoft.com/windows/win32/intl/language-identifier-constants-and-strings
+/// [`Value::from()`]: crate::Value
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct Language {
-    code: u16,
-}
+pub struct LanguageId(u16);
 
-impl Language {
-    fn new(lang: u16, sublang: u16) -> Language {
-        debug_assert_eq!((lang & !LANG_MASK), 0);
-        Language { code: lang | (sublang << SUBLANG_SHIFT) }
-    }
-
-    /// Returns a `Language` value for the given Windows language identifier
-    /// code.
+impl LanguageId {
+    /// Creates a new [`LanguageId`] from a primary language identifier and a
+    /// sub-language identifier.
+    ///
+    /// See [`MAKELANGID`].
+    ///
+    /// [`MAKELANGID`]: https://learn.microsoft.com/windows/win32/api/winnt/nf-winnt-makelangid
     ///
     /// # Examples
     ///
     /// ```
-    /// assert_eq!(msi::Language::from_code(9).code(), 9);
-    /// assert_eq!(msi::Language::from_code(1033).code(), 1033);
-    /// assert_eq!(msi::Language::from_code(3084).code(), 3084);
+    /// use msi::LanguageId;
+    ///
+    /// assert_eq!(LanguageId::new(0x0C, 0x03).tag(), "fr-CA");
+    /// assert_eq!(LanguageId::new(0x09, 0x01).tag(), "en-US");
     /// ```
     #[must_use]
-    pub fn from_code(code: u16) -> Language {
-        Language { code }
+    pub const fn new(primary_language_id: u16, sub_language_id: u16) -> Self {
+        Self(primary_language_id | (sub_language_id << SUBLANG_SHIFT))
     }
 
-    /// Returns a `Language` value for the given RFC 5646 language tag.
+    /// Creates a [`LanguageId`] from a [Windows Language ID].
+    ///
+    /// [Windows Language ID]: https://learn.microsoft.com/openspecs/windows_protocols/ms-lcid/70feba9f-294e-491e-b6eb-56532684c37f
     ///
     /// # Examples
     ///
     /// ```
-    /// assert_eq!(msi::Language::from_tag("en").tag(), "en");
-    /// assert_eq!(msi::Language::from_tag("en-US").tag(), "en-US");
-    /// assert_eq!(msi::Language::from_tag("fr-CA").tag(), "fr-CA");
+    /// use msi::LanguageId;
+    ///
+    /// assert_eq!(LanguageId::from_id(9).id(), 9);
+    /// assert_eq!(LanguageId::from_id(1033).id(), 1033);
+    /// assert_eq!(LanguageId::from_id(3084).id(), 3084);
     /// ```
     #[must_use]
-    pub fn from_tag(tag: &str) -> Language {
-        let parts: Vec<&str> = tag.splitn(2, '-').collect();
-        for &(lang_code, lang_tag, sublangs) in LANGUAGES {
-            if lang_tag == parts[0] {
-                if parts.len() > 1 {
-                    for &(sublang_code, sublang_tag) in sublangs {
-                        if sublang_tag == tag {
-                            return Language::new(lang_code, sublang_code);
-                        }
-                    }
-                    return Language::new(
-                        lang_code,
-                        SUBLANG_CUSTOM_UNSPECIFIED,
-                    );
-                } else {
-                    return Language::new(lang_code, SUBLANG_NEUTRAL);
-                }
-            }
-        }
-        Language::new(LANG_NEUTRAL, SUBLANG_NEUTRAL)
+    #[inline]
+    pub const fn from_id(id: u16) -> Self {
+        Self(id)
     }
 
-    /// Returns the Windows language identifier code for this language.
+    /// Creates a [`LanguageId`] from a [Windows Language Code Identifier (LCID)].
+    ///
+    /// [Windows Language Code Identifier (LCID)]: https://learn.microsoft.com/openspecs/windows_protocols/ms-lcid/70feba9f-294e-491e-b6eb-56532684c37f
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "LCID must be truncated to get the language ID"
+    )]
+    #[must_use]
+    pub const fn from_lcid(lcid: u32) -> Self {
+        Self::from_id(lcid as u16)
+    }
+
+    /// Creates a [`Language`] for a given RFC 5646 language tag.
     ///
     /// # Examples
     ///
     /// ```
-    /// assert_eq!(msi::Language::from_tag("en").code(), 9);
-    /// assert_eq!(msi::Language::from_tag("en-US").code(), 1033);
-    /// assert_eq!(msi::Language::from_tag("fr-CA").code(), 3084);
+    /// use msi::LanguageId;
+    ///
+    /// assert_eq!(LanguageId::from_tag("en").tag(), "en");
+    /// assert_eq!(LanguageId::from_tag("en-US").tag(), "en-US");
+    /// assert_eq!(LanguageId::from_tag("fr-CA").tag(), "fr-CA");
     /// ```
     #[must_use]
-    pub fn code(&self) -> u16 {
-        self.code
+    pub fn from_tag(language_tag: &str) -> Self {
+        LANGUAGES
+            .iter()
+            .copied()
+            .find_map(|(id, tag)| {
+                (tag == language_tag).then(|| Self::from_id(id))
+            })
+            .unwrap_or_default()
     }
 
-    /// Returns the RFC 5646 language tag for this language.  Returns "und"
-    /// (the language tag for "undetermined") if the `Language` value is not
-    /// recognized.
+    /// Returns the raw language ID for this [`LanguageId`].
     ///
     /// # Examples
     ///
     /// ```
-    /// assert_eq!(msi::Language::from_code(9).tag(), "en");
-    /// assert_eq!(msi::Language::from_code(1033).tag(), "en-US");
-    /// assert_eq!(msi::Language::from_code(3084).tag(), "fr-CA");
-    /// assert_eq!(msi::Language::from_code(65535).tag(), "und");
+    /// use msi::LanguageId;
+    ///
+    /// assert_eq!(LanguageId::from_tag("en").id(), 9);
+    /// assert_eq!(LanguageId::from_tag("en-US").id(), 1033);
+    /// assert_eq!(LanguageId::from_tag("fr-CA").id(), 3084);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub const fn id(&self) -> u16 {
+        self.0
+    }
+
+    /// Returns the primary language ID of this [`LanguageId`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use msi::LanguageId;
+    ///
+    /// assert_eq!(LanguageId::from_id(1033).primary_language_id(), 9);
+    /// ```
+    #[must_use]
+    pub const fn primary_language_id(&self) -> u16 {
+        self.0 & LANG_MASK
+    }
+
+    /// Returns the sub-language identifier.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use msi::LanguageId;
+    ///
+    /// assert_eq!(LanguageId::from_id(1033).sub_language_id(), 1);
+    /// ```
+    #[must_use]
+    pub const fn sub_language_id(&self) -> u8 {
+        (self.0 >> SUBLANG_SHIFT) as u8
+    }
+
+    /// Returns the RFC 5646 language tag for this language.
+    ///
+    /// If the language is not recognized, "und" (the language tag for
+    /// "undetermined") is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use msi::LanguageId;
+    ///
+    /// assert_eq!(LanguageId::from_id(9).tag(), "en");
+    /// assert_eq!(LanguageId::from_id(1033).tag(), "en-US");
+    /// assert_eq!(LanguageId::from_id(3084).tag(), "fr-CA");
+    /// assert_eq!(LanguageId::from_id(65535).tag(), "und");
     /// ```
     #[must_use]
     pub fn tag(&self) -> &str {
-        let lang_code = self.code & LANG_MASK;
-        match LANGUAGES.binary_search_by_key(&lang_code, |t| t.0) {
-            Ok(index) => {
-                let (_, lang_tag, sublangs) = LANGUAGES[index];
-                let sublang_code = self.code >> SUBLANG_SHIFT;
-                match sublangs.binary_search_by_key(&sublang_code, |t| t.0) {
-                    Ok(index) => sublangs[index].1,
-                    Err(_) => lang_tag,
-                }
-            }
-            Err(_) => "und",
-        }
+        LANGUAGES
+            .binary_search_by_key(&self.0, |&(id, _)| id)
+            .map_or("und", |index| LANGUAGES[index].1)
     }
 }
 
-// ========================================================================= //
+impl Default for LanguageId {
+    fn default() -> Self {
+        Self::new(LANG_NEUTRAL, SUBLANG_NEUTRAL)
+    }
+}
 
-type SubLanguage = (u16, &'static str);
-// TODO: This table is incomplete.
-const LANGUAGES: &[(u16, &str, &[SubLanguage])] = &[
-    (
-        0x01,
-        "ar",
-        &[
-            (0x01, "ar-SA"),
-            (0x02, "ar-IQ"),
-            (0x03, "ar-EG"),
-            (0x04, "ar-LY"),
-            (0x05, "ar-DZ"),
-            (0x06, "ar-MA"),
-            (0x07, "ar-TN"),
-            (0x08, "ar-OM"),
-            (0x09, "ar-YE"),
-            (0x0a, "ar-SY"),
-            (0x0b, "ar-JO"),
-            (0x0c, "ar-LB"),
-            (0x0d, "ar-KW"),
-            (0x0e, "ar-AE"),
-            (0x0f, "ar-BH"),
-            (0x10, "ar-QA"),
-        ],
-    ),
-    (0x02, "bg", &[(0x01, "bg-BG")]),
-    (0x03, "ca", &[(0x01, "ca-ES")]),
-    (
-        0x04,
-        "zh",
-        &[(0x02, "zh-CN"), (0x03, "zh-HK"), (0x04, "zh-SG"), (0x05, "zh-MO")],
-    ),
-    (0x05, "cs", &[(0x01, "cs-CZ")]),
-    (0x06, "da", &[(0x01, "da-DK")]),
-    (
-        0x07,
-        "de",
-        &[
-            (0x01, "de-DE"),
-            (0x02, "de-CH"),
-            (0x03, "de-AT"),
-            (0x04, "de-LU"),
-            (0x05, "de-LI"),
-        ],
-    ),
-    (0x08, "el", &[(0x01, "el-GR")]),
-    (
-        0x09,
-        "en",
-        &[
-            (0x01, "en-US"),
-            (0x02, "en-GB"),
-            (0x03, "en-AU"),
-            (0x04, "en-CA"),
-            (0x05, "en-NZ"),
-            (0x06, "en-IE"),
-            (0x07, "en-ZA"),
-            (0x08, "en-JM"),
-            (0x09, "en-CB"),
-            (0x0a, "en-BZ"),
-            (0x0b, "en-TT"),
-            (0x0c, "en-ZW"),
-            (0x0d, "en-PH"),
-            (0x10, "en-IN"),
-            (0x11, "en-MY"),
-            (0x12, "en-SG"),
-        ],
-    ),
-    (
-        0x0a,
-        "es",
-        &[
-            (0x01, "es-ES"),
-            (0x02, "es-MX"),
-            (0x04, "es-GT"),
-            (0x05, "es-CR"),
-            (0x06, "es-PA"),
-            (0x07, "es-DO"),
-            (0x08, "es-VE"),
-            (0x09, "es-CO"),
-            (0x0a, "es-PE"),
-            (0x0b, "es-AR"),
-            (0x0c, "es-EC"),
-            (0x0d, "es-CL"),
-            (0x0e, "es-UY"),
-            (0x0f, "es-PY"),
-            (0x10, "es-BO"),
-            (0x11, "es-SV"),
-            (0x12, "es-HN"),
-            (0x13, "es-NI"),
-            (0x14, "es-PR"),
-            (0x15, "es-US"),
-        ],
-    ),
-    (0x0b, "fi", &[(0x01, "fi-FI")]),
-    (
-        0x0c,
-        "fr",
-        &[
-            (0x01, "fr-FR"),
-            (0x02, "fr-BE"),
-            (0x03, "fr-CA"),
-            (0x04, "fr-CH"),
-            (0x05, "fr-LU"),
-            (0x06, "fr-MC"),
-        ],
-    ),
-    (0x0d, "he", &[(0x01, "he-IL")]),
-    (0x0e, "hu", &[(0x01, "hu-HU")]),
-    (0x0f, "is", &[(0x01, "is-IS")]),
-    (0x10, "it", &[(0x01, "it-IT"), (0x02, "it-CH")]),
-    (0x11, "ja", &[(0x01, "ja-JP")]),
-    (0x12, "ko", &[(0x01, "ko-KR")]),
-    (0x13, "nl", &[(0x01, "nl-NL"), (0x02, "nl-BE")]),
-    (0x14, "nb", &[(0x01, "nb-NO")]),
-    (0x15, "pl", &[(0x01, "pl-PL")]),
-    (0x16, "pt", &[(0x01, "pt-BR"), (0x02, "pt-PT")]),
-    (0x17, "rm", &[(0x01, "rm-CH")]),
-    (0x18, "ro", &[(0x01, "ro-RO")]),
-    (0x19, "ru", &[(0x01, "ru-RU")]),
-    (0x1a, "bs", &[(0x05, "bs-BA")]),
-    (0x1b, "sk", &[(0x01, "sk-SK")]),
-    (0x1c, "sq", &[(0x01, "sq-AL")]),
-    (0x1d, "sv", &[(0x01, "sv-SE"), (0x02, "sv-FI")]),
-    (0x1e, "th", &[(0x01, "th-TH")]),
-    (0x1f, "tr", &[(0x01, "tr-TR")]),
-    (0x20, "ur", &[(0x01, "ur-PK")]),
-    (0x21, "id", &[(0x01, "id-ID")]),
-    (0x22, "uk", &[(0x01, "uk-UA")]),
-    (0x23, "be", &[(0x01, "be-BY")]),
-    (0x24, "sl", &[(0x01, "sl-SI")]),
-    (0x25, "et", &[(0x01, "et-EE")]),
-    (0x26, "lv", &[(0x01, "lv-LV")]),
-    (0x27, "lt", &[(0x01, "lt-LT")]),
-    (0x28, "tg", &[(0x01, "tg-TJ")]),
-    (0x29, "fa", &[(0x01, "fa-IR")]),
-    (0x2a, "vi", &[(0x01, "vi-VN")]),
-    (0x2b, "hy", &[(0x01, "hy-AM")]),
-    (0x2c, "az", &[(0x01, "az-AZ")]),
-    (0x2d, "eu", &[(0x01, "eu-ES")]),
-    (0x2f, "mk", &[(0x01, "mk-MK")]),
-    (0x32, "tn", &[(0x01, "tn-ZA"), (0x02, "tn-BW")]),
-    (0x34, "xh", &[(0x01, "xh-ZA")]),
-    (0x35, "zu", &[(0x01, "zu-ZA")]),
-    (0x36, "af", &[(0x01, "af-ZA")]),
-    (0x37, "ka", &[(0x01, "ka-GE")]),
-    (0x38, "fo", &[(0x01, "fo-FO")]),
-    (0x39, "hi", &[(0x01, "hi-IN")]),
-    (0x3a, "mt", &[(0x01, "mt-MT")]),
-    (0x3b, "smn", &[(0x09, "smn-FI")]),
-    (0x3c, "ga", &[(0x02, "ga-IE")]),
-    (0x3e, "ms", &[(0x01, "ms-MY"), (0x02, "ms-BN")]),
-    (0x3f, "kk", &[(0x01, "kk-KZ")]),
-    (0x40, "ky", &[(0x01, "ky-KG")]),
-    (0x41, "sw", &[(0x01, "sw-KE")]),
-    (0x42, "tk", &[(0x01, "tk-TM")]),
-    (0x43, "uz", &[(0x01, "uz-UZ")]),
-    (0x44, "tt", &[(0x01, "tt-RU")]),
-    (0x45, "bn", &[(0x01, "bn-IN"), (0x02, "bn-BD")]),
-    (0x46, "pa", &[(0x01, "pa-IN"), (0x02, "pa-PK")]),
-    (0x47, "gu", &[(0x01, "gu-IN")]),
-    (0x48, "or", &[(0x01, "or-IN")]),
-    (0x49, "ta", &[(0x01, "ta-IN"), (0x02, "ta-LK")]),
-    (0x4a, "te", &[(0x01, "te-IN")]),
-    (0x4b, "kn", &[(0x01, "kn-IN")]),
-    (0x4c, "ml", &[(0x01, "ml-IN")]),
-    (0x4d, "as", &[(0x01, "as-IN")]),
-    (0x4e, "mr", &[(0x01, "mr-IN")]),
-    (0x4f, "sa", &[(0x01, "sa-IN")]),
-    (0x50, "mn", &[(0x01, "mn-MN")]),
-    (0x51, "bo", &[(0x01, "bo-CN")]),
-    (0x52, "cy", &[(0x01, "cy-GB")]),
-    (0x53, "kh", &[(0x01, "kh-KH")]),
-    (0x54, "lo", &[(0x01, "lo-LA")]),
-    (0x56, "gl", &[(0x01, "gl-ES")]),
-    (0x57, "kok", &[(0x01, "kok-IN")]),
-    (0x5a, "syr", &[(0x01, "syr-SY")]),
-    (0x5b, "si", &[(0x01, "si-LK")]),
-    (0x5c, "chr", &[(0x01, "chr-CHR")]),
-    (0x5d, "iu", &[(0x01, "iu-CA")]),
-    (0x5e, "am", &[(0x01, "am-ET")]),
-    (0x5f, "tzm", &[(0x02, "tzm-DZ")]),
-    (0x61, "ne", &[(0x01, "ne-NP"), (0x02, "ne-IN")]),
-    (0x62, "fy", &[(0x01, "fy-NL")]),
-    (0x63, "ps", &[(0x01, "ps-AF")]),
-    (0x64, "tl", &[(0x01, "tl-PH")]),
-    (0x65, "dv", &[(0x01, "dv-MV")]),
-    (0x67, "ff", &[(0x02, "ff-SN")]),
-    (0x68, "ha", &[(0x01, "ha-NG")]),
-    (0x6b, "qu", &[(0x01, "qu-BO"), (0x02, "qu-EC"), (0x03, "qu-PE")]),
-    (0x6c, "nso", &[(0x01, "nso-ZA")]),
-    (0x6d, "ba", &[(0x01, "ba-RU")]),
-    (0x6e, "lb", &[(0x01, "lb-LU")]),
-    (0x6f, "kl", &[(0x01, "kl-GL")]),
-    (0x70, "ig", &[(0x01, "ig-NG")]),
-    (0x73, "ti", &[(0x01, "ti-ET"), (0x02, "ti-ER")]),
-    (0x75, "haw", &[(0x01, "haw-US")]),
-    (0x78, "ii", &[(0x01, "ii-CN")]),
-    (0x7a, "arn", &[(0x01, "arn-CL")]),
-    (0x7c, "moh", &[(0x01, "moh-CA")]),
-    (0x7e, "br", &[(0x01, "br-FR")]),
-    (0x80, "ug", &[(0x01, "ug-CN")]),
-    (0x81, "mi", &[(0x01, "mi-NZ")]),
-    (0x82, "oc", &[(0x01, "oc-FR")]),
-    (0x83, "co", &[(0x01, "co-FR")]),
-    (0x84, "gsw", &[(0x01, "gsw-FR")]),
-    (0x85, "sah", &[(0x01, "sah-RU")]),
-    (0x86, "qut", &[(0x01, "qut-GT")]),
-    (0x87, "rw", &[(0x01, "rw-RW")]),
-    (0x88, "wo", &[(0x01, "wo-SN")]),
-    (0x8c, "prs", &[(0x01, "prs-AF")]),
-    (0x92, "ku", &[(0x01, "ku-IQ")]),
+impl fmt::Display for LanguageId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.id().fmt(f)
+    }
+}
+
+impl fmt::LowerHex for LanguageId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::UpperHex for LanguageId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+impl From<u16> for LanguageId {
+    fn from(code: u16) -> Self {
+        Self::from_id(code)
+    }
+}
+
+impl From<LanguageId> for u16 {
+    fn from(language_id: LanguageId) -> Self {
+        language_id.id()
+    }
+}
+
+/// All non-reserved language IDs defined in section 2.2 of the
+/// [Windows Language Code Identifier (LCID) Reference] revision 16.0 mapped to
+/// their respective RFC 5646 language tag.
+///
+/// [Windows Language Code Identifier (LCID) Reference]: https://learn.microsoft.com/openspecs/windows_protocols/ms-lcid/70feba9f-294e-491e-b6eb-56532684c37f
+const LANGUAGES: &[(u16, &str); 454] = &[
+    (0x0001, "ar"),             // Arabic
+    (0x0002, "bg"),             // Bulgarian
+    (0x0003, "ca"),             // Catalan
+    (0x0004, "zh-Hans"),        // Chinese (Simplified)
+    (0x0005, "cs"),             // Czech
+    (0x0006, "da"),             // Danish
+    (0x0007, "de"),             // German
+    (0x0008, "el"),             // Greek
+    (0x0009, "en"),             // English
+    (0x000A, "es"),             // Spanish
+    (0x000B, "fi"),             // Finnish
+    (0x000C, "fr"),             // French
+    (0x000D, "he"),             // Hebrew
+    (0x000E, "hu"),             // Hungarian
+    (0x000F, "is"),             // Icelandic
+    (0x0010, "it"),             // Italian
+    (0x0011, "ja"),             // Japanese
+    (0x0012, "ko"),             // Korean
+    (0x0013, "nl"),             // Dutch
+    (0x0014, "no"),             // Norwegian (Bokmal)
+    (0x0015, "pl"),             // Polish
+    (0x0016, "pt"),             // Portuguese
+    (0x0017, "rm"),             // Romansh
+    (0x0018, "ro"),             // Romanian
+    (0x0019, "ru"),             // Russian
+    (0x001A, "hr"),             // Croatian
+    (0x001B, "sk"),             // Slovak
+    (0x001C, "sq"),             // Albanian
+    (0x001D, "sv"),             // Swedish
+    (0x001E, "th"),             // Thai
+    (0x001F, "tr"),             // Turkish
+    (0x0020, "ur"),             // Urdu
+    (0x0021, "id"),             // Indonesian
+    (0x0022, "uk"),             // Ukrainian
+    (0x0023, "be"),             // Belarusian
+    (0x0024, "sl"),             // Slovenian
+    (0x0025, "et"),             // Estonian
+    (0x0026, "lv"),             // Latvian
+    (0x0027, "lt"),             // Lithuanian
+    (0x0028, "tg"),             // Tajik (Cyrillic)
+    (0x0029, "fa"),             // Persian
+    (0x002A, "vi"),             // Vietnamese
+    (0x002B, "hy"),             // Armenian
+    (0x002C, "az"),             // Azerbaijani (Latin)
+    (0x002D, "eu"),             // Basque
+    (0x002E, "hsb"),            // Upper Sorbian
+    (0x002F, "mk"),             // Macedonian
+    (0x0030, "st"),             // Sotho
+    (0x0031, "ts"),             // Tsonga
+    (0x0032, "tn"),             // Setswana
+    (0x0033, "ve"),             // Venda
+    (0x0034, "xh"),             // Xhosa
+    (0x0035, "zu"),             // Zulu
+    (0x0036, "af"),             // Afrikaans
+    (0x0037, "ka"),             // Georgian
+    (0x0038, "fo"),             // Faroese
+    (0x0039, "hi"),             // Hindi
+    (0x003A, "mt"),             // Maltese
+    (0x003B, "se"),             // Sami (Northern)
+    (0x003C, "ga"),             // Irish
+    (0x003D, "yi"),             // Yiddish
+    (0x003E, "ms"),             // Malay
+    (0x003F, "kk"),             // Kazakh
+    (0x0040, "ky"),             // Kyrgyz
+    (0x0041, "sw"),             // Kiswahili
+    (0x0042, "tk"),             // Turkmen
+    (0x0043, "uz"),             // Uzbek (Latin)
+    (0x0044, "tt"),             // Tatar
+    (0x0045, "bn"),             // Bangla
+    (0x0046, "pa"),             // Punjabi
+    (0x0047, "gu"),             // Gujarati
+    (0x0048, "or"),             // Odia
+    (0x0049, "ta"),             // Tamil
+    (0x004A, "te"),             // Telugu
+    (0x004B, "kn"),             // Kannada
+    (0x004C, "ml"),             // Malayalam
+    (0x004D, "as"),             // Assamese
+    (0x004E, "mr"),             // Marathi
+    (0x004F, "sa"),             // Sanskrit
+    (0x0050, "mn"),             // Mongolian (Cyrillic)
+    (0x0051, "bo"),             // Tibetan
+    (0x0052, "cy"),             // Welsh
+    (0x0053, "km"),             // Khmer
+    (0x0054, "lo"),             // Lao
+    (0x0055, "my"),             // Burmese
+    (0x0056, "gl"),             // Galician
+    (0x0057, "kok"),            // Konkani
+    (0x0058, "mni"),            // Manipuri
+    (0x0059, "sd"),             // Sindhi
+    (0x005A, "syr"),            // Syriac
+    (0x005B, "si"),             // Sinhala
+    (0x005C, "chr"),            // Cherokee
+    (0x005D, "iu"),             // Inuktitut
+    (0x005E, "am"),             // Amharic
+    (0x005F, "tzm"),            // Central Atlas Tamazight
+    (0x0060, "ks"),             // Kashmiri
+    (0x0061, "ne"),             // Nepali
+    (0x0062, "fy"),             // Frisian
+    (0x0063, "ps"),             // Pashto
+    (0x0064, "fil"),            // Filipino
+    (0x0065, "dv"),             // Divehi
+    (0x0066, "bin"),            // Bini
+    (0x0067, "ff"),             // Fulah
+    (0x0068, "ha"),             // Hausa
+    (0x0069, "ibb"),            // Ibibio
+    (0x006A, "yo"),             // Yoruba
+    (0x006B, "quz"),            // Quechua
+    (0x006C, "nso"),            // Northern Sotho
+    (0x006D, "ba"),             // Bashkir
+    (0x006E, "lb"),             // Luxembourgish
+    (0x006F, "kl"),             // Greenlandic
+    (0x0070, "ig"),             // Igbo
+    (0x0071, "kr"),             // Kanuri
+    (0x0072, "om"),             // Oromo
+    (0x0073, "ti"),             // Tigrinya
+    (0x0074, "gn"),             // Guarani
+    (0x0075, "haw"),            // Hawaiian
+    (0x0076, "la"),             // Latin
+    (0x0077, "so"),             // Somali
+    (0x0078, "ii"),             // Sichuan Yi
+    (0x0079, "pap"),            // Papiamento
+    (0x007A, "arn"),            // Mapuche
+    (0x007C, "moh"),            // Mohawk
+    (0x007E, "br"),             // Breton
+    (0x0080, "ug"),             // Uyghur
+    (0x0081, "mi"),             // Maori
+    (0x0082, "oc"),             // Occitan
+    (0x0083, "co"),             // Corsican
+    (0x0084, "gsw"),            // Alsatian
+    (0x0085, "sah"),            // Sakha
+    (0x0086, "qut"),            // K'iche
+    (0x0087, "rw"),             // Kinyarwanda
+    (0x0088, "wo"),             // Wolof
+    (0x008C, "prs"),            // Dari
+    (0x0091, "gd"),             // Scottish Gaelic
+    (0x0092, "ku"),             // Central Kurdish
+    (0x0093, "quc"),            // K'iche
+    (0x0401, "ar-SA"),          // Arabic - Saudi Arabia
+    (0x0402, "bg-BG"),          // Bulgarian - Bulgaria
+    (0x0403, "ca-ES"),          // Catalan - Spain
+    (0x0404, "zh-TW"),          // Chinese (Traditional) - Taiwan
+    (0x0405, "cs-CZ"),          // Czech - Czech Republic
+    (0x0406, "da-DK"),          // Danish - Denmark
+    (0x0407, "de-DE"),          // German -  Germany
+    (0x0408, "el-GR"),          // Greek - Greece
+    (0x0409, "en-US"),          // English - United States
+    (0x040A, "es-ES_tradnl"),   // Spanish - Spain
+    (0x040B, "fi-FI"),          // Finnish - Finland
+    (0x040C, "fr-FR"),          // French - France
+    (0x040D, "he-IL"),          // Hebrew - Israel
+    (0x040E, "hu-HU"),          // Hungarian - Hungary
+    (0x040F, "is-IS"),          // Icelandic - Iceland
+    (0x0410, "it-IT"),          // Italian - Italy
+    (0x0411, "ja-JP"),          // Japanese - Japan
+    (0x0412, "ko-KR"),          // Korean - Korea
+    (0x0413, "nl-NL"),          // Dutch - Netherlands
+    (0x0414, "nb-NO"),          // Norwegian (Bokmål) - Norway
+    (0x0415, "pl-PL"),          // Polish - Poland
+    (0x0416, "pt-BR"),          // Portuguese - Brazil
+    (0x0417, "rm-CH"),          // Romansh - Switzerland
+    (0x0418, "ro-RO"),          // Romanian - Romania
+    (0x0419, "ru-RU"),          // Russian - Russia
+    (0x041A, "hr-HR"),          // Croatian - Croatia
+    (0x041B, "sk-SK"),          // Slovak - Slovakia
+    (0x041C, "sq-AL"),          // Albanian - Albania
+    (0x041D, "sv-SE"),          // Swedish - Sweden
+    (0x041E, "th-TH"),          // Thai - Thailand
+    (0x041F, "tr-TR"),          // Turkish - Türkiye
+    (0x0420, "ur-PK"),          // Urdu - Pakistan
+    (0x0421, "id-ID"),          // Indonesian - Indonesia
+    (0x0422, "uk-UA"),          // Ukrainian - Ukraine
+    (0x0423, "be-BY"),          // Belarusian - Belarus
+    (0x0424, "sl-SI"),          // Slovenian - Slovenia
+    (0x0425, "et-EE"),          // Estonian - Estonia
+    (0x0426, "lv-LV"),          // Latvian - Latvia
+    (0x0427, "lt-LT"),          // Lithuanian - Lithuania
+    (0x0428, "tg-Cyrl-TJ"),     // Tajik (Cyrillic) - Tajikistan
+    (0x0429, "fa-IR"),          // Persian - Iran
+    (0x042A, "vi-VN"),          // Vietnamese - Vietnam
+    (0x042B, "hy-AM"),          // Armenian - Armenia
+    (0x042C, "az-Latn-AZ"),     // Azerbaijani (Latin) - Azerbaijan
+    (0x042D, "eu-ES"),          // Basque - Spain
+    (0x042E, "hsb-DE"),         // Upper Sorbian - Germany
+    (0x042F, "mk-MK"),          // Macedonian - North Macedonia
+    (0x0430, "st-ZA"),          // Sotho - South Africa
+    (0x0431, "ts-ZA"),          // Tsonga - South Africa
+    (0x0432, "tn-ZA"),          // Setswana - South Africa
+    (0x0433, "ve-ZA"),          // Venda - South Africa
+    (0x0434, "xh-ZA"),          // Xhosa - South Africa
+    (0x0435, "zu-ZA"),          // Zulu - South Africa
+    (0x0436, "af-ZA"),          // Afrikaans - South Africa
+    (0x0437, "ka-GE"),          // Georgian - Georgia
+    (0x0438, "fo-FO"),          // Faroese - Faroe Islands
+    (0x0439, "hi-IN"),          // Hindi - India
+    (0x043A, "mt-MT"),          // Maltese - Malta
+    (0x043B, "se-NO"),          // Sami (Northern) - Norway
+    (0x043D, "yi-001"),         // Yiddish - World
+    (0x043E, "ms-MY"),          // Malay - Malaysia
+    (0x043F, "kk-KZ"),          // Kazakh - Kazakhstan
+    (0x0440, "ky-KG"),          // Kyrgyz - Kyrgyzstan
+    (0x0441, "sw-KE"),          // Kiswahili - Kenya
+    (0x0442, "tk-TM"),          // Turkmen - Turkmenistan
+    (0x0443, "uz-Latn-UZ"),     // Uzbek (Latin) - Uzbekistan
+    (0x0444, "tt-RU"),          // Tatar - Russia
+    (0x0445, "bn-IN"),          // Bangla - India
+    (0x0446, "pa-IN"),          // Punjabi - India
+    (0x0447, "gu-IN"),          // Gujarati - India
+    (0x0448, "or-IN"),          // Odia - India
+    (0x0449, "ta-IN"),          // Tamil - India
+    (0x044A, "te-IN"),          // Telugu - India
+    (0x044B, "kn-IN"),          // Kannada - India
+    (0x044C, "ml-IN"),          // Malayalam - India
+    (0x044D, "as-IN"),          // Assamese - India
+    (0x044E, "mr-IN"),          // Marathi - India
+    (0x044F, "sa-IN"),          // Sanskrit - India
+    (0x0450, "mn-MN"),          // Mongolian (Cyrillic) - Mongolia
+    (0x0451, "bo-CN"),          // Tibetan - People's Republic of China
+    (0x0452, "cy-GB"),          // Welsh - United Kingdom
+    (0x0453, "km-KH"),          // Khmer - Cambodia
+    (0x0454, "lo-LA"),          // Lao - Laos
+    (0x0455, "my-MM"),          // Burmese - Myanmar
+    (0x0456, "gl-ES"),          // Galician - Spain
+    (0x0457, "kok-IN"),         // Konkani - India
+    (0x0458, "mni-IN"),         // Manipuri - India
+    (0x0459, "sd-Deva-IN"),     // Sindhi (Devanagari) - India
+    (0x045A, "syr-SY"),         // Syriac - Syria
+    (0x045B, "si-LK"),          // Sinhala - Sri Lanka
+    (0x045C, "chr-Cher-US"),    // Cherokee - United States
+    (0x045D, "iu-Cans-CA"), // Inuktitut (Canadian Aboriginal Syllabics) - Canada
+    (0x045E, "am-ET"),      // Amharic - Ethiopia
+    (0x045F, "tzm-Arab-MA"), // Central Atlas Tamazight (Arabic) - Morocco
+    (0x0460, "ks-Arab"),    // Kashmiri (Arabic)
+    (0x0461, "ne-NP"),      // Nepali - Nepal
+    (0x0462, "fy-NL"),      // Frisian - Netherlands
+    (0x0463, "ps-AF"),      // Pashto - Afghanistan
+    (0x0464, "fil-PH"),     // Filipino - Philippines
+    (0x0465, "dv-MV"),      // Divehi - Maldives
+    (0x0466, "bin-NG"),     // Bini - Nigeria
+    (0x0467, "ff-Latn-NG"), // Fulah (Latin) - Nigeria
+    (0x0468, "ha-Latn-NG"), // Hausa (Latin) - Nigeria
+    (0x0469, "ibb-NG"),     // Ibibio - Nigeria
+    (0x046A, "yo-NG"),      // Yoruba - Nigeria
+    (0x046B, "quz-BO"),     // Quechua - Bolivia
+    (0x046C, "nso-ZA"),     // Northern Sotho - South Africa
+    (0x046D, "ba-RU"),      // Bashkir - Russia
+    (0x046E, "lb-LU"),      // Luxembourgish - Luxembourg
+    (0x046F, "kl-GL"),      // Greenlandic - Greenland
+    (0x0470, "ig-NG"),      // Igbo - Nigeria
+    (0x0471, "kr-Latn-NG"), // Kanuri (Latin) - Nigeria
+    (0x0472, "om-ET"),      // Oromo - Ethiopia
+    (0x0473, "ti-ET"),      // Tigrinya - Ethiopia
+    (0x0474, "gn-PY"),      // Guarani - Paraguay
+    (0x0475, "haw-US"),     // Hawaiian - United States
+    (0x0476, "la-VA"),      // Latin - Vatican City
+    (0x0477, "so-SO"),      // Somali - Somalia
+    (0x0478, "ii-CN"),      // Sichuan Yi - People's Republic of China
+    (0x0479, "pap-029"),    // Papiamento - Caribbean
+    (0x047A, "arn-CL"),     // Mapuche - Chile
+    (0x047C, "moh-CA"),     // Mohawk - Canada
+    (0x047E, "br-FR"),      // Breton - France
+    (0x0480, "ug-CN"),      // Uyghur - People's Republic of China
+    (0x0481, "mi-NZ"),      // Maori - New Zealand
+    (0x0482, "oc-FR"),      // Occitan - France
+    (0x0483, "co-FR"),      // Corsican - France
+    (0x0484, "gsw-FR"),     // Alsatian - France
+    (0x0485, "sah-RU"),     // Sakha - Russia
+    (0x0486, "qut-GT"),     // K'iche - Guatemala
+    (0x0487, "rw-RW"),      // Kinyarwanda - Rwanda
+    (0x0488, "wo-SN"),      // Wolof - Senegal
+    (0x048C, "prs-AF"),     // Dari - Afghanistan
+    (0x048D, "plt-MG"),     // Malagasy - Madagascar
+    (0x048E, "zh-yue-HK"), // Chinese (Traditional) Cantonese - Hong Kong S.A.R.
+    (0x048F, "tdd-Tale-CN"), // Tai Nüa - People's Republic of China
+    (0x0490, "khb-Talu-CN"), // Lü - People's Republic of China
+    (0x0491, "gd-GB"),     // Scottish Gaelic - United Kingdom
+    (0x0492, "ku-Arab-IQ"), // Central Kurdish Iraq
+    (0x0493, "quc-CO"),    // K'iche - Colombia
+    (0x0501, "qps-ploc"),  // Pseudo Language
+    (0x05FE, "qps-ploca"), // Pseudo Language (Mirrored)
+    (0x0801, "ar-IQ"),     // Arabic - Iraq
+    (0x0803, "ca-ES-valencia"), // Catalan - Valencia
+    (0x0804, "zh-CN"),     // Chinese (Simplified) - People's Republic of China
+    (0x0807, "de-CH"),     // German - Switzerland
+    (0x0809, "en-GB"),     // English - United Kingdom
+    (0x080A, "es-MX"),     // Spanish - Mexico
+    (0x080C, "fr-BE"),     // French - Belgium
+    (0x0810, "it-CH"),     // Italian - Switzerland
+    (0x0811, "ja-Ploc-JP"), // Japanese (Pseudo)
+    (0x0813, "nl-BE"),     // Dutch - Belgium
+    (0x0814, "nn-NO"),     // Norwegian (Nynorsk) - Norway
+    (0x0816, "pt-PT"),     // Portuguese - Portugal
+    (0x0818, "ro-MD"),     // Romanian - Moldova
+    (0x0819, "ru-MD"),     // Russian - Moldova
+    (0x081A, "sr-Latn-CS"), // Serbian (Latin) - Serbia and Montenegro
+    (0x081D, "sv-FI"),     // Swedish - Finland
+    (0x0820, "ur-IN"),     // Urdu - India
+    (0x082C, "az-Cyrl-AZ"), // Azerbaijani (Cyrillic) - Azerbaijan
+    (0x082E, "dsb-DE"),    // Lower Sorbian - Germany
+    (0x0832, "tn-BW"),     // Setswana - Botswana
+    (0x083B, "se-SE"),     // Sami (Northern) - Sweden
+    (0x083C, "ga-IE"),     // Irish - Ireland
+    (0x083E, "ms-BN"),     // Malay - Brunei Darussalam
+    (0x083F, "kk-Latn-KZ"), // Kazakh (Latin) - Kazakhstan
+    (0x0843, "uz-Cyrl-UZ"), // Uzbek (Cyrillic) - Uzbekistan
+    (0x0845, "bn-BD"),     // Bangla - Bangladesh
+    (0x0846, "pa-Arab-PK"), // Punjabi (Arabic) - Pakistan
+    (0x0849, "ta-LK"),     // Tamil - Sri Lanka
+    (0x0850, "mn-Mong-CN"), // Mongolian (Traditional Mongolian) - People's Republic of China
+    (0x0851, "bo-BT"),      // Tibetan - Bhutan
+    (0x0859, "sd-Arab-PK"), // Sindhi (Arabic) - Pakistan
+    (0x085D, "iu-Latn-CA"), // Inuktitut (Latin) - Canada
+    (0x085F, "tzm-Latn-DZ"), // Central Atlas Tamazight (Latin) - Algeria
+    (0x0860, "ks-Deva-IN"), // Kashmiri (Devanagari) - India
+    (0x0861, "ne-IN"),      // Nepali - India
+    (0x0867, "ff-Latn-SN"), // Fulah (Latin) - Senegal
+    (0x086B, "quz-EC"),     // Quechua - Ecuador
+    (0x0873, "ti-ER"),      // Tigrinya - Eritrea
+    (0x09FF, "qps-plocm"),  // Pseudo Language (Mirrored)
+    (0x0C01, "ar-EG"),      // Arabic - Egypt
+    (0x0C04, "zh-HK"),      // Chinese (Traditional) - Hong Kong S.A.R.
+    (0x0C07, "de-AT"),      // German - Austria
+    (0x0C09, "en-AU"),      // English - Australia
+    (0x0C0A, "es-ES"),      // Spanish - Spain
+    (0x0C0C, "fr-CA"),      // French - Canada
+    (0x0C1A, "sr-Cyrl-CS"), // Serbian (Cyrillic) - Serbia and Montenegro
+    (0x0C3B, "se-FI"),      // Sami (Northern) - Finland
+    (0x0C50, "mn-Mong-MN"), // Mongolian (Traditional Mongolian) - Mongolia
+    (0x0C51, "dz-BT"),      // Dzongkha - Bhutan
+    (0x0C5F, "tmz-MA"),     // Central Atlas Tamazight - Morocco
+    (0x0C6B, "quz-PE"),     // Quechua - Peru
+    (0x1001, "ar-LY"),      // Arabic - Libya
+    (0x1004, "zh-SG"),      // Chinese (Simplified) - Singapore
+    (0x1007, "de-LU"),      // German - Luxembourg
+    (0x1009, "en-CA"),      // English - Canada
+    (0x100A, "es-GT"),      // Spanish - Guatemala
+    (0x100C, "fr-CH"),      // French - Switzerland
+    (0x101A, "hr-BA"),      // Croatian (Latin) - Bosnia and Herzegovina
+    (0x103B, "smj-NO"),     // Sami (Lule) - Norway
+    (0x105F, "tzm-Tfng-MA"), // Central Atlas Tamazight (Tifinagh) - Morocco
+    (0x1401, "ar-DZ"),      // Arabic - Algeria
+    (0x1404, "zh-MO"),      // Chinese (Traditional) - Macao S.A.R.
+    (0x1407, "de-LI"),      // German - Liechtenstein
+    (0x1409, "en-NZ"),      // English - New Zealand
+    (0x140A, "es-CR"),      // Spanish - Costa Rica
+    (0x140C, "fr-LU"),      // French - Luxembourg
+    (0x141A, "bs-Latn-BA"), // Bosnian (Latin) - Bosnia and Herzegovina
+    (0x143B, "smj-SE"),     // Sami (Lule) - Sweden
+    (0x1801, "ar-MA"),      // Arabic - Morocco
+    (0x1809, "en-IE"),      // English - Ireland
+    (0x180A, "es-PA"),      // Spanish - Panama
+    (0x180C, "fr-MC"),      // French - Monaco
+    (0x181A, "sr-Latn-BA"), // Serbian (Latin) - Bosnia and Herzegovina
+    (0x183B, "sma-NO"),     // Sami (Southern) - Norway
+    (0x1C01, "ar-TN"),      // Arabic - Tunisia
+    (0x1C09, "en-ZA"),      // English - South Africa
+    (0x1C0A, "es-DO"),      // Spanish - Dominican Republic
+    (0x1C0C, "fr-029"),     // French - Caribbean
+    (0x1C1A, "sr-Cyrl-BA"), // Serbian (Cyrillic) - Bosnia and Herzegovina
+    (0x1C3B, "sma-SE"),     // Sami (Southern) - Sweden
+    (0x2001, "ar-OM"),      // Arabic - Oman
+    (0x2009, "en-JM"),      // English - Jamaica
+    (0x200A, "es-VE"),      // Spanish - Venezuela
+    (0x200C, "fr-RE"),      // French - Réunion
+    (0x201A, "bs-Cyrl-BA"), // Bosnian (Cyrillic) - Bosnia and Herzegovina
+    (0x203B, "sms-FI"),     // Sami (Skolt) - Finland
+    (0x2401, "ar-YE"),      // Arabic - Yemen
+    (0x2409, "en-029"),     // English - Caribbean
+    (0x240A, "es-CO"),      // Spanish - Colombia
+    (0x240C, "fr-CD"),      // French - Congo (DRC)
+    (0x241A, "sr-Latn-RS"), // Serbian (Latin) - Serbia
+    (0x243B, "smn-FI"),     // Sami (Inari) - Finland
+    (0x2801, "ar-SY"),      // Arabic - Syria
+    (0x2809, "en-BZ"),      // English - Belize
+    (0x280A, "es-PE"),      // Spanish - Peru
+    (0x280C, "fr-SN"),      // French - Senegal
+    (0x281A, "sr-Cyrl-RS"), // Serbian (Cyrillic) - Serbia
+    (0x2C01, "ar-JO"),      // Arabic - Jordan
+    (0x2C09, "en-TT"),      // English - Trinidad and Tobago
+    (0x2C0A, "es-AR"),      // Spanish - Argentina
+    (0x2C0C, "fr-CM"),      // French - Cameroon
+    (0x2C1A, "sr-Latn-ME"), // Serbian (Latin) - Montenegro
+    (0x3001, "ar-LB"),      // Arabic - Lebanon
+    (0x3009, "en-ZW"),      // English - Zimbabwe
+    (0x300A, "es-EC"),      // Spanish - Ecuador
+    (0x300C, "fr-CI"),      // French - Côte d'Ivoire
+    (0x301A, "sr-Cyrl-ME"), // Serbian (Cyrillic) - Montenegro
+    (0x3401, "ar-KW"),      // Arabic - Kuwait
+    (0x3409, "en-PH"),      // English - Philippines
+    (0x340A, "es-CL"),      // Spanish - Chile
+    (0x340C, "fr-ML"),      // French - Mali
+    (0x3801, "ar-AE"),      // Arabic - U.A.E.
+    (0x3809, "en-ID"),      // English - Indonesia
+    (0x380A, "es-UY"),      // Spanish - Uruguay
+    (0x380C, "fr-MA"),      // French - Morocco
+    (0x3C01, "ar-BH"),      // Arabic - Bahrain
+    (0x3C09, "en-HK"),      // English - Hong Kong S.A.R.
+    (0x3C0A, "es-PY"),      // Spanish - Paraguay
+    (0x3C0C, "fr-HT"),      // French - Haiti
+    (0x4001, "ar-QA"),      // Arabic - Qatar
+    (0x4009, "en-IN"),      // English - India
+    (0x400A, "es-BO"),      // Spanish - Bolivia
+    (0x4401, "ar-Ploc-SA"), // Arabic (Pseudo) - Saudi Arabia
+    (0x4409, "en-MY"),      // English - Malaysia
+    (0x440A, "es-SV"),      // Spanish - El Salvador
+    (0x4801, "ar-145"),     // Arabic - Western Asia
+    (0x4809, "en-SG"),      // English - Singapore
+    (0x480A, "es-HN"),      // Spanish - Honduras
+    (0x4C09, "en-AE"),      // English - U.A.E.
+    (0x4C0A, "es-NI"),      // Spanish - Nicaragua
+    (0x5009, "en-BH"),      // English - Bahrain
+    (0x500A, "es-PR"),      // Spanish - Puerto Rico
+    (0x5409, "en-EG"),      // English - Egypt
+    (0x540A, "es-US"),      // Spanish - United States
+    (0x5809, "en-JO"),      // English - Jordan
+    (0x580A, "es-419"),     // Spanish - Latin America and Caribbean
+    (0x5C09, "en-KW"),      // English - Kuwait
+    (0x5C0A, "es-CU"),      // Spanish - Cuba
+    (0x6009, "en-TR"),      // English - Türkiye
+    (0x6409, "en-YE"),      // English - Yemen
+    (0x641A, "bs-Cyrl"),    // Bosnian (Cyrillic)
+    (0x681A, "bs-Latn"),    // Bosnian (Latin)
+    (0x6C1A, "sr-Cyrl"),    // Serbian (Cyrillic)
+    (0x701A, "sr-Latn"),    // Serbian (Latin)
+    (0x703B, "smn"),        // Sami (Inari)
+    (0x742C, "az-Cyrl"),    // Azerbaijani (Cyrillic)
+    (0x743B, "sms"),        // Sami (Skolt)
+    (0x7804, "zh"),         // Chinese (Simplified)
+    (0x7814, "nn"),         // Norwegian (Nynorsk)
+    (0x781A, "bs"),         // Bosnian (Latin)
+    (0x782C, "az-Latn"),    // Azerbaijani (Latin)
+    (0x783B, "sma"),        // Sami (Southern)
+    (0x783F, "kk-Cyrl"),    // Kazakh (Cyrillic)
+    (0x7843, "uz-Cyrl"),    // Uzbek (Cyrillic)
+    (0x7850, "mn-Cyrl"),    // Mongolian (Cyrillic)
+    (0x785D, "iu-Cans"),    // Inuktitut (Canadian Aboriginal Syllabics)
+    (0x785F, "tzm-Tfng"),   // Central Atlas Tamazight (Tifinagh)
+    (0x7C04, "zh-Hant"),    // Chinese (Traditional)
+    (0x7C14, "nb"),         // Norwegian (Bokmål)
+    (0x7C1A, "sr"),         // Serbian
+    (0x7C28, "tg-Cyrl"),    // Tajik (Cyrillic)
+    (0x7C2E, "dsb"),        // Lower Sorbian
+    (0x7C3B, "smj"),        // Sami (Lule)
+    (0x7C3F, "kk-Latn"),    // Kazakh (Latin)
+    (0x7C43, "uz-Latn"),    // Uzbek (Latin)
+    (0x7C46, "pa-Arab"),    // Punjabi (Arabic)
+    (0x7C50, "mn-Mong"),    // Mongolian (Traditional Mongolian)
+    (0x7C59, "sd-Arab"),    // Sindhi (Arabic)
+    (0x7C5C, "chr-Cher"),   // Cherokee
+    (0x7C5D, "iu-Latn"),    // Inuktitut (Latin)
+    (0x7C5F, "tzm-Latn"),   // Central Atlas Tamazight (Latin)
+    (0x7C67, "ff-Latn"),    // Fulah (Latin)
+    (0x7C68, "ha-Latn"),    // Hausa (Latin)
+    (0x7C92, "ku-Arab"),    // Central Kurdish
+    (0xE40C, "fr-015"),     // French - Northern Africa
 ];
-
-// ========================================================================= //
 
 #[cfg(test)]
 mod tests {
@@ -339,98 +671,36 @@ mod tests {
 
     #[test]
     fn lang_codes_are_unique() {
-        let mut codes = HashSet::<u16>::new();
-        for &(lang_code, _, _) in LANGUAGES {
+        let mut codes = HashSet::new();
+        for &(id, _) in LANGUAGES {
             assert!(
-                !codes.contains(&lang_code),
-                "Language table repeats lang code 0x{lang_code:02x}"
+                codes.insert(id),
+                "Language table repeats lang code {id:#02x}"
             );
-            codes.insert(lang_code);
         }
     }
 
     #[test]
     fn lang_tags_are_unique() {
-        let mut tags = HashSet::<&str>::new();
-        for &(_, lang_tag, _) in LANGUAGES {
+        let mut tags = HashSet::new();
+        for &(_, tag) in LANGUAGES {
             assert!(
-                !tags.contains(&lang_tag),
-                "Language table repeats lang tag {lang_tag:?}"
+                tags.insert(tag),
+                "Language table repeats language tag {tag:?}"
             );
-            tags.insert(lang_tag);
         }
     }
 
     #[test]
     fn lang_codes_are_sorted() {
         let mut prev_code: u16 = 0;
-        for &(lang_code, _, _) in LANGUAGES {
+        for &(id, _) in LANGUAGES {
             assert!(
-                lang_code >= prev_code,
-                "LANGUAGES table is not sorted, 0x{lang_code:02x} is out of \
+                id >= prev_code,
+                "LANGUAGES table is not sorted, {id:#02x} is out of \
                  place"
             );
-            prev_code = lang_code;
-        }
-    }
-
-    #[test]
-    fn sublang_codes_are_unique() {
-        for &(lang_code, lang_tag, sublangs) in LANGUAGES {
-            let mut codes = HashSet::<u16>::new();
-            for &(sublang_code, _) in sublangs {
-                assert!(
-                    !codes.contains(&sublang_code),
-                    "Sublanguage table for 0x{lang_code:02x} ({lang_tag}) \
-                     repeats sublang code 0x{sublang_code:02x}"
-                );
-                codes.insert(sublang_code);
-            }
-        }
-    }
-
-    #[test]
-    fn sublang_tags_are_unique() {
-        for &(lang_code, lang_tag, sublangs) in LANGUAGES {
-            let mut tags = HashSet::<&str>::new();
-            for &(_, sublang_tag) in sublangs {
-                assert!(
-                    !tags.contains(&sublang_tag),
-                    "Sublanguage table for 0x{lang_code:02x} ({lang_tag}) \
-                     repeats sublang tag {sublang_tag:?}"
-                );
-                tags.insert(sublang_tag);
-            }
-        }
-    }
-
-    #[test]
-    fn sublang_codes_are_sorted() {
-        for &(lang_code, lang_tag, sublangs) in LANGUAGES {
-            let mut prev_code: u16 = 0;
-            for &(sublang_code, sublang_tag) in sublangs {
-                assert!(
-                    sublang_code >= prev_code,
-                    "Sublanguage table for 0x{lang_code:02x} ({lang_tag}) \
-                     is not sorted; 0x{sublang_code:02x} ({sublang_tag}) is \
-                     out of place"
-                );
-                prev_code = sublang_code;
-            }
-        }
-    }
-
-    #[test]
-    fn sublang_tags_start_with_lang_tag() {
-        for &(_, lang_tag, sublangs) in LANGUAGES {
-            for &(_, sublang_tag) in sublangs {
-                assert!(
-                    sublang_tag.starts_with(&format!("{lang_tag}-")),
-                    "{sublang_tag:?} is not a sublanguage of {lang_tag:?}"
-                );
-            }
+            prev_code = id;
         }
     }
 }
-
-// ========================================================================= //

--- a/src/internal/summary.rs
+++ b/src/internal/summary.rs
@@ -1,5 +1,5 @@
 use crate::internal::codepage::CodePage;
-use crate::internal::language::Language;
+use crate::internal::language::LanguageId;
 use crate::internal::propset::{OperatingSystem, PropertySet, PropertyValue};
 use crate::internal::timestamp::Timestamp;
 use std::io::{self, Read, Seek, Write};
@@ -270,7 +270,7 @@ impl SummaryInfo {
 
     /// Gets the list of languages from the "template" property, if one is set.
     /// This indicates the languages that this package supports.
-    pub fn languages(&self) -> Vec<Language> {
+    pub fn languages(&self) -> Vec<LanguageId> {
         match self.properties.get(PROPERTY_TEMPLATE) {
             Some(PropertyValue::LpStr(template)) => {
                 let parts: Vec<&str> = template.splitn(2, ';').collect();
@@ -278,7 +278,7 @@ impl SummaryInfo {
                     parts[1]
                         .split(',')
                         .filter_map(|code| code.parse().ok())
-                        .map(Language::from_code)
+                        .map(LanguageId::from_id)
                         .collect()
                 } else {
                     Vec::new()
@@ -289,7 +289,7 @@ impl SummaryInfo {
     }
 
     /// Sets the list of languages in the "template" property.
-    pub fn set_languages(&mut self, languages: &[Language]) {
+    pub fn set_languages(&mut self, languages: &[LanguageId]) {
         let mut template = match self.properties.get(PROPERTY_TEMPLATE) {
             Some(PropertyValue::LpStr(template)) => template
                 .split_once(';')
@@ -305,7 +305,7 @@ impl SummaryInfo {
             } else {
                 template.push(',');
             }
-            template.push_str(&format!("{}", language.code()));
+            template.push_str(&format!("{}", language.id()));
         }
         self.properties.set(PROPERTY_TEMPLATE, PropertyValue::LpStr(template));
     }
@@ -522,7 +522,7 @@ impl SummaryInfo {
 mod tests {
     use super::SummaryInfo;
     use crate::internal::{
-        language::Language,
+        language::LanguageId,
         summary::{
             PROPERTY_CREATION_TIME, PROPERTY_LAST_PRINTED,
             PROPERTY_LAST_SAVE_TIME,
@@ -534,10 +534,10 @@ mod tests {
     #[test]
     fn set_properties() {
         let languages = vec![
-            Language::from_tag("en-CA"),
-            Language::from_tag("fr-CA"),
-            Language::from_tag("en-US"),
-            Language::from_tag("es-MX"),
+            LanguageId::from_tag("en-CA"),
+            LanguageId::from_tag("fr-CA"),
+            LanguageId::from_tag("en-US"),
+            LanguageId::from_tag("es-MX"),
         ];
         let uuid =
             Uuid::parse_str("0000002a-000c-0005-0c03-0938362b0809").unwrap();
@@ -630,12 +630,12 @@ mod tests {
         // Set language before setting arch:
         let mut summary_info = SummaryInfo::new();
         assert_eq!(summary_info.arch(), None);
-        summary_info.set_languages(&[Language::from_tag("en")]);
+        summary_info.set_languages(&[LanguageId::from_tag("en")]);
         assert_eq!(summary_info.arch(), None);
-        assert_eq!(summary_info.languages(), vec![Language::from_tag("en")]);
+        assert_eq!(summary_info.languages(), vec![LanguageId::from_tag("en")]);
         summary_info.set_arch("Intel");
         assert_eq!(summary_info.arch(), Some("Intel"));
-        assert_eq!(summary_info.languages(), vec![Language::from_tag("en")]);
+        assert_eq!(summary_info.languages(), vec![LanguageId::from_tag("en")]);
 
         // Set arch before setting language:
         let mut summary_info = SummaryInfo::new();
@@ -644,8 +644,8 @@ mod tests {
         summary_info.set_arch("Intel");
         assert_eq!(summary_info.languages(), vec![]);
         assert_eq!(summary_info.arch(), Some("Intel"));
-        summary_info.set_languages(&[Language::from_tag("en")]);
-        assert_eq!(summary_info.languages(), vec![Language::from_tag("en")]);
+        summary_info.set_languages(&[LanguageId::from_tag("en")]);
+        assert_eq!(summary_info.languages(), vec![LanguageId::from_tag("en")]);
         assert_eq!(summary_info.arch(), Some("Intel"));
     }
 }

--- a/src/internal/value.rs
+++ b/src/internal/value.rs
@@ -1,4 +1,4 @@
-use crate::internal::language::Language;
+use crate::internal::language::LanguageId;
 use crate::internal::stringpool::{StringPool, StringRef};
 use std::convert::From;
 use std::fmt;
@@ -123,18 +123,18 @@ impl From<String> for Value {
 
 /// Returns a string value containing the code for the given language, suitable
 /// for storing in a column with the `Language` category.
-impl From<Language> for Value {
-    fn from(language: Language) -> Value {
-        Value::Str(format!("{}", language.code()))
+impl From<LanguageId> for Value {
+    fn from(language: LanguageId) -> Value {
+        Value::Str(format!("{}", language.id()))
     }
 }
 
 /// Returns a string value containing the codes for the given languages,
 /// suitable for storing in a column with the `Language` category.
-impl<'a> From<&'a [Language]> for Value {
-    fn from(languages: &'a [Language]) -> Value {
+impl<'a> From<&'a [LanguageId]> for Value {
+    fn from(languages: &'a [LanguageId]) -> Value {
         let codes: Vec<String> =
-            languages.iter().map(|lang| lang.code().to_string()).collect();
+            languages.iter().map(|lang| lang.id().to_string()).collect();
         Value::Str(codes.join(","))
     }
 }
@@ -203,7 +203,7 @@ impl ValueRef {
 mod tests {
     use super::{Value, ValueRef};
     use crate::internal::codepage::CodePage;
-    use crate::internal::language::Language;
+    use crate::internal::language::LanguageId;
     use crate::internal::stringpool::StringPool;
     use uuid::Uuid;
 
@@ -237,15 +237,15 @@ mod tests {
             Value::Str("foobar".to_string())
         );
         assert_eq!(
-            Value::from(Language::from_tag("en-US")),
+            Value::from(LanguageId::from_tag("en-US")),
             Value::Str("1033".to_string())
         );
         assert_eq!(
             Value::from(&[
-                Language::from_code(1033),
-                Language::from_code(2107),
-                Language::from_code(3131),
-            ] as &[Language],),
+                LanguageId::from_id(1033),
+                LanguageId::from_id(2107),
+                LanguageId::from_id(3131),
+            ] as &[LanguageId],),
             Value::Str("1033,2107,3131".to_string())
         );
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::internal::category::Category;
 pub use crate::internal::codepage::CodePage;
 pub use crate::internal::column::{Column, ColumnBuilder, ColumnType};
 pub use crate::internal::expr::Expr;
-pub use crate::internal::language::Language;
+pub use crate::internal::language::LanguageId;
 pub use crate::internal::package::{Package, PackageType, Tables};
 pub use crate::internal::query::{Delete, Insert, Select, Update};
 pub use crate::internal::stream::{StreamReader, StreamWriter, Streams};


### PR DESCRIPTION
This pull request refactors `Language` to more closely match the [LanguageId](https://learn.microsoft.com/windows/win32/intl/language-identifiers) specification.

The main reason for this was to ensure the list of `LANGUAGES` was complete. This now has all the languages defined in the [Windows Language Code Identifier (LCID) Reference revision 16.0](https://chatgpt.com/c/6a1f6f7c-89c0-832d-8596-50efddfa6700), using their full 16-bit identifier. The benefit of this is it reduces the two binary searches on `tag()` to just one binary search. This is also beneficial since binary searches are more efficient on larger arrays and less efficient, sometimes even less than a linear search, on small arrays.